### PR TITLE
Fix short address decoding

### DIFF
--- a/contracts/lib/RLP.sol
+++ b/contracts/lib/RLP.sol
@@ -299,12 +299,9 @@ library RLP {
         view
         returns (address data)
     {
-        require(isData(self));
-        var (rStartPos, len) = _decode(self);
-        require(len == 20);
-        assembly {
-            data := div(mload(rStartPos), exp(256, 12))
-        }
+        var (, len) = _decode(self);
+        require(len <= 20);
+        return address(toUint(self));
     }
 
     // Get the payload offset.


### PR DESCRIPTION
Example addresses:
```
0x0014F55A50b281EFD12294f0Cda821Bd8171e920
0x0000000000000000000000000000000000000000
```