### PR TITLE
MarketplacePredicate.verifyDeprecation

### DIFF
--- a/contracts/child/misc/Marketplace.sol
+++ b/contracts/child/misc/Marketplace.sol
@@ -11,7 +11,7 @@ contract Marketplace {
     uint256 tokenIdOrAmount;
   }
 
-  function decode(bytes memory data) internal returns(Order memory order) {
+  function decode(bytes memory data) internal pure returns(Order memory order) {
     (order.token, order.sig, order.tokenIdOrAmount) = abi.decode(data, (address, bytes, uint256));
   }
 

--- a/contracts/root/depositManager/DepositManager.sol
+++ b/contracts/root/depositManager/DepositManager.sol
@@ -28,6 +28,14 @@ contract DepositManager is DepositManagerStorage, IDepositManager, IERC721Receiv
     _;
   }
 
+  modifier onlyWithdrawManager() {
+    require(
+      msg.sender == registry.getWithdrawManagerAddress(),
+      "UNAUTHORIZED_WITHDRAW_MANAGER_ONLY"
+    );
+    _;
+  }
+
   // deposit ETH by sending to this contract
   function () external payable {
     depositEther();
@@ -35,7 +43,7 @@ contract DepositManager is DepositManagerStorage, IDepositManager, IERC721Receiv
 
   function transferAssets(address _token, address _user, uint256 _amountOrNFTId)
     external
-    isPredicateAuthorized
+    onlyWithdrawManager
   {
     address wethToken = registry.getWethTokenAddress();
     if (registry.isERC721(_token)) {

--- a/contracts/root/depositManager/DepositManager.sol
+++ b/contracts/root/depositManager/DepositManager.sol
@@ -20,13 +20,13 @@ contract DepositManager is DepositManagerStorage, IDepositManager, IERC721Receiv
     _;
   }
 
-  modifier isPredicateAuthorized() {
-    require(
-      uint8(registry.predicates(msg.sender)) != 0,
-      "Not a valid predicate"
-    );
-    _;
-  }
+  // modifier isPredicateAuthorized() {
+  //   require(
+  //     uint8(registry.predicates(msg.sender)) != 0,
+  //     "Not a valid predicate"
+  //   );
+  //   _;
+  // }
 
   modifier onlyWithdrawManager() {
     require(

--- a/contracts/root/predicates/ERC20Predicate.sol
+++ b/contracts/root/predicates/ERC20Predicate.sol
@@ -60,16 +60,16 @@ contract ERC20Predicate is IErcPredicate {
   /**
    * @notice Start an exit by referencing the preceding (reference) transaction
    * @param data RLP encoded data of the reference tx(s) that encodes the following fields for each tx
-   * headerNumber Header block number of which the reference tx was a part of
-   * blockProof Proof that the block header (in the child chain) is a leaf in the submitted merkle root
-   * blockNumber Block number of which the reference tx is a part of
-   * blockTime Reference tx block time
-   * blocktxRoot Transactions root of block
-   * blockReceiptsRoot Receipts root of block
-   * receipt Receipt of the reference transaction
-   * receiptProof Merkle proof of the reference receipt
-   * branchMask Merkle proof branchMask for the receipt
-   * logIndex Log Index to read from the receipt
+      * headerNumber Header block number of which the reference tx was a part of
+      * blockProof Proof that the block header (in the child chain) is a leaf in the submitted merkle root
+      * blockNumber Block number of which the reference tx is a part of
+      * blockTime Reference tx block time
+      * blocktxRoot Transactions root of block
+      * blockReceiptsRoot Receipts root of block
+      * receipt Receipt of the reference transaction
+      * receiptProof Merkle proof of the reference receipt
+      * branchMask Merkle proof branchMask for the receipt
+      * logIndex Log Index to read from the receipt
    * @param exitTx Signed exit transaction
    * @return address rootToken that the exit corresponds to
    * @return uint256 exitAmount
@@ -107,52 +107,39 @@ contract ERC20Predicate is IErcPredicate {
     referenceTxData.age = withdrawManager.verifyInclusion(data, 0 /* offset */, false /* verifyTxInclusion */)
         .add(referenceTxData.age); // Add the logIndex and oIndex from the receipt
 
+    ReferenceTxData memory _referenceTxData;
+
+    if (referenceTx.length > 10) {
+      _referenceTxData = processReferenceTx(
+        referenceTx[16].toBytes(), // receipt
+        referenceTx[19].toUint(), // logIndex
+        msg.sender, // participant
+        false /* isChallenge */
+      );
+      require(
+        _referenceTxData.childToken == referenceTxData.childToken,
+        "child tokens in the referenced txs do not match"
+      );
+      require(
+        _referenceTxData.rootToken == referenceTxData.rootToken,
+        "root tokens in the referenced txs do not match"
+      );
+      _referenceTxData.age = withdrawManager.verifyInclusion(data, 10 /* offset */, false /* verifyTxInclusion */)
+        .add(_referenceTxData.age);
+    }
+
     sendBond(); // send BOND_AMOUNT to withdrawManager
 
     // last bit is to differentiate whether the sender or receiver of the in-flight tx is starting an exit
     uint256 exitId = referenceTxData.age << 1;
     if (msg.sender == exitTxData.signer) exitId |= 1;
-
-    if (referenceTx.length <= 10) {
-      withdrawManager.addExitToQueue(
-        msg.sender, referenceTxData.childToken, referenceTxData.rootToken,
-        exitTxData.amountOrToken, exitTxData.txHash, false /* isRegularExit */, exitId
-      );
-      withdrawManager.addInput(exitId, referenceTxData.age /* age of input */, exitTxData.signer);
-      return (referenceTxData.rootToken, exitTxData.amountOrToken);
-    }
-
-    // referenceTx.length > 10 means the exitor sent along another input UTXO to the exit tx
-    // This will be used to exit with the pre-existing balance on the chain along with the couterparty signed exit tx
-    ReferenceTxData memory _referenceTxData = processReferenceTx(
-      referenceTx[16].toBytes(), // receipt
-      referenceTx[19].toUint(), // logIndex
-      msg.sender, // participant
-      false /* isChallenge */
-    );
-    require(
-      _referenceTxData.childToken == referenceTxData.childToken,
-      "child tokens in the referenced txs do not match"
-    );
-    require(
-      _referenceTxData.rootToken == referenceTxData.rootToken,
-      "root tokens in the referenced txs do not match"
-    );
-    _referenceTxData.age = withdrawManager.verifyInclusion(data, 10 /* offset */, false /* verifyTxInclusion */)
-        .add(_referenceTxData.age);
-
-    // If the other referenced receipt was more recent, modify the exitId
-    // This is to reflect what MoreVp calls the "age of the youngest input"
-    if (_referenceTxData.age > referenceTxData.age) {
-      exitId = _referenceTxData.age << 1;
-    }
     withdrawManager.addExitToQueue(
       msg.sender, referenceTxData.childToken, referenceTxData.rootToken,
       exitTxData.amountOrToken.add(_referenceTxData.closingBalance), exitTxData.txHash, false /* isRegularExit */,
       exitId
     );
-    withdrawManager.addInput(exitId, referenceTxData.age, exitTxData.signer);
-    withdrawManager.addInput(exitId, _referenceTxData.age, msg.sender);
+    withdrawManager.addInput(exitId, referenceTxData.age, exitTxData.signer, referenceTxData.rootToken);
+    withdrawManager.addInput(exitId, _referenceTxData.age, msg.sender, referenceTxData.rootToken);
     return (referenceTxData.rootToken, exitTxData.amountOrToken.add(_referenceTxData.closingBalance));
   }
 
@@ -161,18 +148,18 @@ contract ERC20Predicate is IErcPredicate {
    * @param exit ABI encoded PlasmaExit data
    * @param inputUtxo ABI encoded Input UTXO data
    * @param challengeData RLP encoded data of the challenge reference tx that encodes the following fields
-   * headerNumber Header block number of which the reference tx was a part of
-   * blockProof Proof that the block header (in the child chain) is a leaf in the submitted merkle root
-   * blockNumber Block number of which the reference tx is a part of
-   * blockTime Reference tx block time
-   * blocktxRoot Transactions root of block
-   * blockReceiptsRoot Receipts root of block
-   * receipt Receipt of the reference transaction
-   * receiptProof Merkle proof of the reference receipt
-   * branchMask Merkle proof branchMask for the receipt
-   * logIndex Log Index to read from the receipt
-   * tx Challenge transaction
-   * txProof Merkle proof of the challenge tx
+      * headerNumber Header block number of which the reference tx was a part of
+      * blockProof Proof that the block header (in the child chain) is a leaf in the submitted merkle root
+      * blockNumber Block number of which the reference tx is a part of
+      * blockTime Reference tx block time
+      * blocktxRoot Transactions root of block
+      * blockReceiptsRoot Receipts root of block
+      * receipt Receipt of the reference transaction
+      * receiptProof Merkle proof of the reference receipt
+      * branchMask Merkle proof branchMask for the receipt
+      * logIndex Log Index to read from the receipt
+      * tx Challenge transaction
+      * txProof Merkle proof of the challenge tx
    * @return Whether or not the state is deprecated
    */
   function verifyDeprecation(bytes calldata exit, bytes calldata inputUtxo, bytes calldata challengeData)
@@ -180,7 +167,9 @@ contract ERC20Predicate is IErcPredicate {
     returns (bool)
   {
     PlasmaExit memory _exit = decodeExit(exit);
-    (uint256 age, address signer) = decodeInputUtxo(inputUtxo);
+    (uint256 age, address signer,,) = decodeInputUtxo(inputUtxo);
+    // it's possible to challenge either an input utxo or the exit directly
+    // age = Math.max(_exit. >> 1, )
     RLPReader.RLPItem[] memory _challengeData = challengeData.toRlpItem().toList();
     ExitTxData memory challengeTxData = processChallengeTx(_challengeData[10].toBytes());
     require(
@@ -197,33 +186,57 @@ contract ERC20Predicate is IErcPredicate {
     );
 
     // receipt alone is not enough for a challenge. It is required to check that the challenge tx was included as well
-    uint256 ageOfChallengeTx = withdrawManager.verifyInclusion(challengeData, 0, true /* verifyTxInclusion */);
     ReferenceTxData memory referenceTxData = processReferenceTx(
       _challengeData[6].toBytes(), // receipt
       _challengeData[9].toUint(), // logIndex
       challengeTxData.signer,
-      true /* isChallenge */);
+      true /* isChallenge */
+    );
+    referenceTxData.age = withdrawManager.verifyInclusion(challengeData, 0, true /* verifyTxInclusion */)
+      .add(referenceTxData.age);
     require(
       challengeTxData.childToken == referenceTxData.childToken,
       "Tx and receipt do not correspond to the same child token"
     );
-    // The challenge tx should be more recent that the Utxo being challenged
-    return ageOfChallengeTx.add(referenceTxData.age) > age;
+    require(
+      referenceTxData.age > age,
+      "Age of challenge log in the receipt needs to be more recent than Utxo being challenged"
+    );
+    return true;
   }
 
-  function onFinalizeExit(address exitor, address token, uint256 tokenId)
-    external
-    onlyWithdrawManager
-  {
-    depositManager.transferAssets(token, exitor, tokenId);
-  }
+  // function onFinalizeExit(address exitor, address token, uint256 tokenId)
+  //   external
+  //   onlyWithdrawManager
+  // {
+  //   depositManager.transferAssets(token, exitor, tokenId);
+  // }
 
+  /**
+   * @notice Parse a ERC20 LogTransfer event in the receipt
+   * @param state abi encoded (data, participant, verifyInclusion)
+      * data is RLP encoded reference tx receipt that encodes the following fields
+      * headerNumber Header block number of which the reference tx was a part of
+      * blockProof Proof that the block header (in the child chain) is a leaf in the submitted merkle root
+      * blockNumber Block number of which the reference tx is a part of
+      * blockTime Reference tx block time
+      * blocktxRoot Transactions root of block
+      * blockReceiptsRoot Receipts root of block
+      * receipt Receipt of the reference transaction
+      * receiptProof Merkle proof of the reference receipt
+      * branchMask Merkle proof branchMask for the receipt
+      * logIndex Log Index to read from the receipt
+      * tx Challenge transaction
+      * txProof Merkle proof of the challenge tx
+    * @return abi encoded (closingBalance, ageOfUtxo, childToken, rootToken)
+   */
   function interpretStateUpdate(bytes calldata state)
     external
     view
     returns(bytes memory)
   {
-    (bytes memory _data, address participant, bool verifyInclusion) = abi.decode(state, (bytes, address, bool));
+    // isChallenge Is the state being parsed for a challenge
+    (bytes memory _data, address participant, bool verifyInclusion, bool isChallenge) = abi.decode(state, (bytes, address, bool, bool));
     RLPReader.RLPItem[] memory referenceTx = _data.toRlpItem().toList();
     bytes memory receipt = referenceTx[6].toBytes();
     uint256 logIndex = referenceTx[9].toUint();
@@ -235,7 +248,11 @@ contract ERC20Predicate is IErcPredicate {
     bytes memory logData = inputItems[2].toBytes();
     inputItems = inputItems[1].toList(); // topics
     data.rootToken = address(RLPReader.toUint(inputItems[1]));
-    (data.closingBalance, data.age) = processStateUpdate(inputItems, logData, participant);
+    if (isChallenge) {
+      processChallenge(inputItems, participant);
+    } else {
+      (data.closingBalance, data.age) = processStateUpdate(inputItems, logData, participant);
+    }
     data.age = data.age.add(logIndex.mul(MAX_LOGS));
     if (verifyInclusion) {
       data.age = data.age.add(withdrawManager.verifyInclusion(_data, 0, false /* verifyTxInclusion */));

--- a/contracts/root/predicates/ERC20Predicate.sol
+++ b/contracts/root/predicates/ERC20Predicate.sol
@@ -140,12 +140,9 @@ contract ERC20Predicate is IErcPredicate {
       exitId
     );
     withdrawManager.addInput(exitId, referenceTxData.age, exitTxData.signer, referenceTxData.rootToken);
-    // If exitor did not have pre=exiting balance on the chain => _referenceTxData has default values;
+    // If exitor did not have pre-exiting balance on the chain => _referenceTxData has default values;
     // In that case, the following input acts as a "dummy" input UTXO to challenge token spends by the exitor
-    withdrawManager.addInput(
-      exitId, _referenceTxData.age > 0 ? _referenceTxData.age : 0,
-      msg.sender, referenceTxData.rootToken
-    );
+    withdrawManager.addInput(exitId, _referenceTxData.age, msg.sender, referenceTxData.rootToken);
     return (referenceTxData.rootToken, exitTxData.amountOrToken.add(_referenceTxData.closingBalance));
   }
 

--- a/contracts/root/predicates/MarketplacePredicate.sol
+++ b/contracts/root/predicates/MarketplacePredicate.sol
@@ -6,6 +6,7 @@ import { ECVerify } from "../../common/lib/ECVerify.sol";
 import { Math } from "openzeppelin-solidity/contracts/math/Math.sol";
 import { RLPEncode } from "../../common/lib/RLPEncode.sol";
 import { RLPReader } from "solidity-rlp/contracts/RLPReader.sol";
+import { SafeMath } from "openzeppelin-solidity/contracts/math/SafeMath.sol";
 
 import { IPredicate, PredicateUtils } from "./IPredicate.sol";
 import { Registry } from "../../common/Registry.sol";
@@ -15,6 +16,7 @@ import { IDepositManager } from "../depositManager/IDepositManager.sol";
 contract MarketplacePredicate is PredicateUtils {
   using RLPReader for bytes;
   using RLPReader for RLPReader.RLPItem;
+  using SafeMath for uint256;
 
   // 0xe660b9e4 = keccak256('executeOrder(bytes,bytes,bytes32,uint256,address)').slice(0, 4)
   bytes4 constant EXECUTE_ORDER_FUNC_SIG = 0xe660b9e4;
@@ -36,7 +38,7 @@ contract MarketplacePredicate is PredicateUtils {
   }
 
   struct ExitTxData {
-    // token1 and amount1 should correspond to what the exitor (msg.sender) signed over
+    // token1 and amount1 correspond to what the utxoOwner (tradeParticipant) signed over
     uint256 amount1;
     uint256 amount2;
     address token1;
@@ -60,31 +62,65 @@ contract MarketplacePredicate is PredicateUtils {
     registry = Registry(_registry);
   }
 
+  /**
+   * @notice Start an exit from in-flight marketplace tx
+   * @param data RLP encoded array of input utxos
+      * data[n] (n < 2) is abi encoded as (predicateAddress, RLP encoded reference tx)
+      * data[n][1] is RLP encoded reference tx that encodes the following fields
+        * headerNumber Header block number of which the reference tx was a part of
+        * blockProof Proof that the block header (in the child chain) is a leaf in the submitted merkle root
+        * blockNumber Block number of which the reference tx is a part of
+        * blockTime Reference tx block time
+        * blocktxRoot Transactions root of block
+        * blockReceiptsRoot Receipts root of block
+        * receipt Receipt of the reference transaction
+        * receiptProof Merkle proof of the reference receipt
+        * branchMask Merkle proof branchMask for the receipt
+        * logIndex Log Index to read from the receipt
+      * data[2] is the child token that the user wishes to start an exit for
+   * @param exitTx  Signed (marketplace.executeOrder) exit transaction
+   */
   function startExit(bytes calldata data, bytes calldata exitTx)
     external
     payable
     isBondProvided
   {
-    ExitTxData memory exitTxData = processExitTx(exitTx, withdrawManager.networkId());
+    ExitTxData memory exitTxData = processExitTx(exitTx, withdrawManager.networkId(), msg.sender);
     RLPReader.RLPItem[] memory referenceTx = data.toRlpItem().toList();
     (address predicate, bytes memory preState) = abi.decode(referenceTx[0].toBytes(), (address, bytes));
     require(
       uint8(registry.predicates(predicate)) != 0,
       "Not a valid predicate"
     );
-    ReferenceTxData memory reference1 = processPreState(predicate, preState, msg.sender, true);
+    ReferenceTxData memory reference1 = processLogTransferReceipt(predicate, preState, msg.sender, true /* verifyInclusionInCheckpoint */, false /* isChallenge */);
     validateTokenBalance(reference1.childToken, exitTxData.token1, reference1.closingBalance, exitTxData.amount1);
+
+    // process the second reference tx, which is the proof-of-counterparty funds for the exchange token
     (predicate, preState) = abi.decode(referenceTx[1].toBytes(), (address, bytes));
     require(
       uint8(registry.predicates(predicate)) != 0,
       "Not a valid predicate"
     );
-    ReferenceTxData memory reference2 = processPreState(predicate, preState, exitTxData.counterParty, true);
+    ReferenceTxData memory reference2 = processLogTransferReceipt(predicate, preState, exitTxData.counterParty, true /* verifyInclusionInCheckpoint */, false /* isChallenge */);
     validateTokenBalance(reference2.childToken, exitTxData.token2, reference2.closingBalance, exitTxData.amount2);
-    uint256 exitId = Math.max(reference1.age, reference2.age) << 1; // What MoreVp calls the age of the youngest input
-    address exitChildToken = address(RLPReader.toUint(referenceTx[2]));
+
+    ReferenceTxData memory reference3;
+    address exitChildToken;
+    if (referenceTx.length == 4) {
+      (predicate, preState) = abi.decode(referenceTx[2].toBytes(), (address, bytes));
+      reference3 = processLogTransferReceipt(predicate, preState, msg.sender, true /* verifyInclusionInCheckpoint */, false /* isChallenge */);
+      exitChildToken = address(RLPReader.toUint(referenceTx[3]));
+      require(
+        reference2.childToken == reference3.childToken,
+        "Child token doesnt match"
+      );
+    } else {
+      exitChildToken = address(RLPReader.toUint(referenceTx[2]));
+    }
 
     sendBond(); // send BOND_AMOUNT to withdrawManager
+
+    uint256 exitId = Math.max(Math.max(reference1.age, reference2.age), reference3.age) << 1; // age of the youngest input
     if (exitChildToken == reference1.childToken) {
       withdrawManager.addExitToQueue(
         msg.sender, exitChildToken, reference1.rootToken,
@@ -95,21 +131,53 @@ contract MarketplacePredicate is PredicateUtils {
     } else if (exitChildToken == reference2.childToken) {
       withdrawManager.addExitToQueue(
         msg.sender, exitChildToken, reference2.rootToken,
-        exitTxData.amount2,
+        exitTxData.amount2.add(reference3.closingBalance),
         exitTxData.txHash, false /* isRegularExit */,
         exitId
       );
     }
-    withdrawManager.addInput(exitId, reference1.age /* age of input */, msg.sender /* signer */);
-    withdrawManager.addInput(exitId, reference2.age /* age of input */, exitTxData.counterParty /* signer */);
+    // @todo Support batch
+    withdrawManager.addInput(exitId, reference1.age /* age of input */, msg.sender /* party whom this utxo belongs to */, reference1.rootToken);
+    withdrawManager.addInput(exitId, reference2.age, exitTxData.counterParty, reference2.rootToken);
+    withdrawManager.addInput(exitId, reference3.age, msg.sender, reference3.rootToken);
   }
 
-  function onFinalizeExit(address exitor, address token, uint256 tokenId)
+  function verifyDeprecation(bytes calldata exit, bytes calldata inputUtxo, bytes calldata challengeData)
     external
-    onlyWithdrawManager
+    view
+    returns (bool)
   {
-    depositManager.transferAssets(token, exitor, tokenId);
+    PlasmaExit memory _exit = decodeExit(exit);
+    (uint256 age, address utxoOwner, address predicate, address childToken) = decodeInputUtxo(inputUtxo);
+
+    RLPReader.RLPItem[] memory _challengeData = challengeData.toRlpItem().toList();
+    ExitTxData memory challengeTxData = processExitTx(_challengeData[10].toBytes(), withdrawManager.networkId(), utxoOwner);
+
+    // receipt alone is not enough for a challenge. It is required to check that the challenge tx was included as well
+    // Challenge will be considered successful if a more recent LogTransfer event is found
+    // Interestingly, that will be determined by erc20/721 predicate
+    ReferenceTxData memory referenceTxData = processLogTransferReceipt(predicate, challengeData, utxoOwner, true /* verifyInclusionInCheckpoint */, true /* isChallenge */);
+    require(
+      referenceTxData.childToken == childToken && challengeTxData.token1 == childToken,
+      "LogTransferReceipt, challengeTx token and challenged utxo token do not match"
+    );
+    require(
+      challengeTxData.txHash != _exit.txHash,
+      "Cannot challenge with the exit tx"
+    );
+    require(
+      referenceTxData.age > age,
+      "Age of challenge log in the receipt needs to be more recent than Utxo being challenged"
+    );
+    return true;
   }
+
+  // function onFinalizeExit(address exitor, address token, uint256 tokenId)
+  //   external
+  //   onlyWithdrawManager
+  // {
+  //   depositManager.transferAssets(token, exitor, tokenId);
+  // }
 
   function validateTokenBalance(
     address childToken,
@@ -136,22 +204,23 @@ contract MarketplacePredicate is PredicateUtils {
     }
   }
 
-  function processPreState(
+  function processLogTransferReceipt(
     address predicate,
     bytes memory preState,
     address participant,
-    bool verifyInclusionInCheckpoint)
+    bool verifyInclusionInCheckpoint,
+    bool isChallenge)
     internal
     view
     returns(ReferenceTxData memory _referenceTx)
   {
-    bytes memory _preState = IPredicate(predicate).interpretStateUpdate(abi.encode(preState, participant, verifyInclusionInCheckpoint));
+    bytes memory _preState = IPredicate(predicate).interpretStateUpdate(abi.encode(preState, participant, verifyInclusionInCheckpoint, isChallenge));
     (_referenceTx.closingBalance, _referenceTx.age, _referenceTx.childToken, _referenceTx.rootToken) = abi.decode(_preState, (uint256, uint256, address,address));
   }
 
-  function processExitTx(bytes memory exitTx, bytes memory networkId)
+  function processExitTx(bytes memory exitTx, bytes memory networkId, address tradeParticipant)
     internal
-    view
+    pure
     returns(ExitTxData memory txData)
   {
     RLPReader.RLPItem[] memory txList = exitTx.toRlpItem().toList();
@@ -162,15 +231,16 @@ contract MarketplacePredicate is PredicateUtils {
       funcSig == EXECUTE_ORDER_FUNC_SIG,
       "Not executeOrder transaction"
     );
-    txData = verifySignatures(executeOrder, marketplaceContract);
+    txData = verifySignatures(executeOrder, marketplaceContract, tradeParticipant);
     (, txData.txHash) = getAddressFromTx(txList, networkId);
   }
 
   function verifySignatures(
     ExecuteOrderData memory executeOrder,
-    address marketplaceContract)
+    address marketplaceContract,
+    address tradeParticipant)
     internal
-    view
+    pure
     returns(ExitTxData memory)
   {
     Order memory order1 = decodeOrder(executeOrder.data1);
@@ -199,13 +269,14 @@ contract MarketplacePredicate is PredicateUtils {
     // Cannot check for deactivated sigs here on the root chain
     address tradeParticipant2 = ECVerify.ecrecovery(dataHash, order2.sig);
     require(executeOrder.taker == tradeParticipant2, "Orders are not complimentary");
-    if (tradeParticipant1 == msg.sender) {
+    // token1 and amount1 in ExitTxData should correspond to what the tradeParticipant signed over (spent in the trade)
+    if (tradeParticipant1 == tradeParticipant) {
       return ExitTxData(order1.amount, order2.amount, order1.token, order2.token, tradeParticipant2, bytes32(0));
     }
-    else if (tradeParticipant2 == msg.sender) {
+    else if (tradeParticipant2 == tradeParticipant) {
       return ExitTxData(order2.amount, order1.amount, order2.token, order1.token, tradeParticipant1, bytes32(0));
     }
-    revert("Provided tx doesnt concern the exitor (msg.sender)");
+    revert("Provided tx doesnt concern the exitor (tradeParticipant)");
   }
 
   function decodeExecuteOrder(bytes memory orderData)

--- a/contracts/root/withdrawManager/IWithdrawManager.sol
+++ b/contracts/root/withdrawManager/IWithdrawManager.sol
@@ -15,9 +15,9 @@ contract IWithdrawManager {
       uint256 priority)
     external;
 
-  function addInput(uint256 exitId, uint256 age, address signer) external;
+  function addInput(uint256 exitId, uint256 age, address utxoOwner, address token) external;
 
-  function challengeExit(uint256 exitId, uint256 inputId, bytes calldata challengeData) external;
+  function challengeExit(uint256 exitId, uint256 inputId, bytes calldata challengeData, address adjudicatorPredicate) external;
 
   // overridden by inheriting contract
   bytes public networkId;

--- a/contracts/root/withdrawManager/WithdrawManager.sol
+++ b/contracts/root/withdrawManager/WithdrawManager.sol
@@ -250,6 +250,10 @@ contract WithdrawManager is WithdrawManagerStorage, IWithdrawManager {
       "Invalid exit or input id"
     );
     require(
+      registry.predicates(adjudicatorPredicate) != Registry.Type.Invalid,
+      "INVALID_PREDICATE"
+    );
+    require(
       IPredicate(adjudicatorPredicate).verifyDeprecation(
         encodeExit(exit),
         encodeInputUtxo(inputId, input),

--- a/contracts/root/withdrawManager/WithdrawManagerStorage.sol
+++ b/contracts/root/withdrawManager/WithdrawManagerStorage.sol
@@ -7,7 +7,9 @@ import { ExitNFT } from "./ExitNFT.sol";
 
 contract ExitsDataStructure {
   struct Input {
-    address signer;
+    address utxoOwner;
+    address predicate;
+    address token;
   }
 
   struct PlasmaExit {
@@ -15,7 +17,6 @@ contract ExitsDataStructure {
     bytes32 txHash;
     address owner;
     address token;
-    address predicate;
     bool isRegularExit;
     // Mapping from age of input to Input
     mapping(uint256 => Input) inputs;

--- a/contracts/root/withdrawManager/WithdrawManagerStorage.sol
+++ b/contracts/root/withdrawManager/WithdrawManagerStorage.sol
@@ -49,9 +49,6 @@ contract WithdrawManagerHeader is ExitsDataStructure {
 }
 
 contract WithdrawManagerStorage is ProxyStorage, WithdrawManagerHeader {
-  // uint256 constant internal HEADER_BLOCK_NUMBER_WEIGHT = 10 ** 30;
-  // uint256 constant internal CHILD_BLOCK_NUMBER_WEIGHT = 1 << 96;
-  // uint256 constant internal BRANCH_MASK_WEIGHT = 1 << 64;
   uint256 internal constant HALF_EXIT_PERIOD = 1 weeks;
 
   // Bonded exits collaterized at 0.1 ETH
@@ -69,9 +66,10 @@ contract WithdrawManagerStorage is ProxyStorage, WithdrawManagerHeader {
 
   // ERC721, ERC20 and Weth transfers require 155000, 100000, 52000 gas respectively
   // Processing each exit in a while loop iteration requires ~52000 gas (@todo check if this changed)
-  uint32 constant internal ITERATION_GAS = 52000;
-  // So putting an upper limit of 155000 + 52000 + leeway for predicate.onFinalizeExit()
-  uint32 constant internal ON_FINALIZE_GAS_LIMIT = 250000;
+  // uint32 constant internal ITERATION_GAS = 52000;
+
+  // So putting an upper limit of 155000 + 52000 + leeway
+  uint32 constant internal ON_FINALIZE_GAS_LIMIT = 210000;
 
   uint256 public exitWindow;
 }

--- a/contracts/test/MarketplacePredicateTest.sol
+++ b/contracts/test/MarketplacePredicateTest.sol
@@ -11,7 +11,7 @@ contract MarketplacePredicateTest is MarketplacePredicate {
     MarketplacePredicate(address(0x0), address(0x0), address(0x0))
     public {}
 
-  function processPreStateTest(
+  function processLogTransferReceiptTest(
     address predicate,
     bytes memory data,
     address participant)
@@ -19,7 +19,7 @@ contract MarketplacePredicateTest is MarketplacePredicate {
     view
     returns(bytes memory b)
   {
-    ReferenceTxData memory _referenceTx = super.processPreState(predicate, data, participant, false);
+    ReferenceTxData memory _referenceTx = super.processLogTransferReceipt(predicate, data, participant, false, false);
     b = abi.encode(_referenceTx.closingBalance, _referenceTx.age, _referenceTx.childToken, _referenceTx.rootToken);
   }
 
@@ -28,7 +28,7 @@ contract MarketplacePredicateTest is MarketplacePredicate {
     view
     returns(bytes memory b)
   {
-    ExitTxData memory txData = super.processExitTx(exitTx, "\x0d");
+    ExitTxData memory txData = super.processExitTx(exitTx, "\x0d", msg.sender);
     b = abi.encode(txData.amount1, txData.amount2, txData.token1, txData.token2, txData.counterParty);
   }
 

--- a/migrations/2_deploy_root_contracts.js
+++ b/migrations/2_deploy_root_contracts.js
@@ -82,25 +82,25 @@ module.exports = async function(deployer, network) {
   deployer
     .then(async() => {
       console.log('linking libs...')
-      await bluebird.map(libDeps, async e => {
-        await deployer.deploy(e.lib)
-        deployer.link(e.lib, e.contracts)
-      })
+      // await bluebird.map(libDeps, async e => {
+      //   await deployer.deploy(e.lib)
+      //   deployer.link(e.lib, e.contracts)
+      // })
 
       console.log('deploying contracts...')
-      await Promise.all([
-        deployer.deploy(Registry),
-        deployer.deploy(StakeManager),
-        deployer.deploy(WithdrawManager),
-        deployer.deploy(DepositManager)
-      ])
+      // await Promise.all([
+      //   deployer.deploy(Registry),
+      //   deployer.deploy(StakeManager),
+      //   deployer.deploy(WithdrawManager),
+      //   deployer.deploy(DepositManager)
+      // ])
 
-      await Promise.all([
-        deployer.deploy(RootChain, Registry.address),
-        deployer.deploy(ERC20Predicate, WithdrawManager.address, DepositManager.address),
-        deployer.deploy(ERC721Predicate, WithdrawManager.address, DepositManager.address),
-        deployer.deploy(MarketplacePredicate, WithdrawManager.address, DepositManager.address, Registry.address),
-        deployer.deploy(MarketplacePredicateTest)
-      ])
+      // await Promise.all([
+      //   deployer.deploy(RootChain, Registry.address),
+      //   deployer.deploy(ERC20Predicate, WithdrawManager.address, DepositManager.address),
+      //   deployer.deploy(ERC721Predicate, WithdrawManager.address, DepositManager.address),
+      //   deployer.deploy(MarketplacePredicate, WithdrawManager.address, DepositManager.address, Registry.address),
+      //   deployer.deploy(MarketplacePredicateTest)
+      // ])
     })
 }

--- a/migrations/2_deploy_root_contracts.js
+++ b/migrations/2_deploy_root_contracts.js
@@ -82,25 +82,25 @@ module.exports = async function(deployer, network) {
   deployer
     .then(async() => {
       console.log('linking libs...')
-      // await bluebird.map(libDeps, async e => {
-      //   await deployer.deploy(e.lib)
-      //   deployer.link(e.lib, e.contracts)
-      // })
+      await bluebird.map(libDeps, async e => {
+        await deployer.deploy(e.lib)
+        deployer.link(e.lib, e.contracts)
+      })
 
       console.log('deploying contracts...')
-      // await Promise.all([
-      //   deployer.deploy(Registry),
-      //   deployer.deploy(StakeManager),
-      //   deployer.deploy(WithdrawManager),
-      //   deployer.deploy(DepositManager)
-      // ])
+      await Promise.all([
+        deployer.deploy(Registry),
+        deployer.deploy(StakeManager),
+        deployer.deploy(WithdrawManager),
+        deployer.deploy(DepositManager)
+      ])
 
-      // await Promise.all([
-      //   deployer.deploy(RootChain, Registry.address),
-      //   deployer.deploy(ERC20Predicate, WithdrawManager.address, DepositManager.address),
-      //   deployer.deploy(ERC721Predicate, WithdrawManager.address, DepositManager.address),
-      //   deployer.deploy(MarketplacePredicate, WithdrawManager.address, DepositManager.address, Registry.address),
-      //   deployer.deploy(MarketplacePredicateTest)
-      // ])
+      await Promise.all([
+        deployer.deploy(RootChain, Registry.address),
+        deployer.deploy(ERC20Predicate, WithdrawManager.address, DepositManager.address),
+        deployer.deploy(ERC721Predicate, WithdrawManager.address, DepositManager.address),
+        deployer.deploy(MarketplacePredicate, WithdrawManager.address, DepositManager.address, Registry.address),
+        deployer.deploy(MarketplacePredicateTest)
+      ])
     })
 }

--- a/test/helpers/utils.js
+++ b/test/helpers/utils.js
@@ -189,8 +189,8 @@ export async function verifyDeprecation(withdrawManager, predicate, exitId, inpu
   )
   // console.log('exitData', exitData)
   const inputUtxoData = web3.eth.abi.encodeParameters(
-    ['uint256', 'address'],
-    [options.age, options.signer]
+    ['uint256', 'address', 'address', 'address'],
+    [options.age, options.signer, predicate.address, options.childToken]
   )
   // console.log('inputUtxoData', inputUtxoData)
   return predicate.verifyDeprecation(exitData, inputUtxoData, challengeData)

--- a/test/root/ExitScenarios.test.js
+++ b/test/root/ExitScenarios.test.js
@@ -141,7 +141,6 @@ contract('Misc Predicates tests', async function(accounts) {
     const challengeData = utils.buildChallengeData(predicateTestUtils.buildInputFromCheckpoint(utxo3m))
     // This will be used to assert that challenger received the bond amount
     const originalBalance = web3.utils.toBN(await web3.eth.getBalance(accounts[0]))
-    // const challenge = await contracts.withdrawManager.challengeExit(exitId, ageOfUtxo1a, challengeData, contracts.ERC20Predicate.address)
     const challenge = await contracts.withdrawManager.challengeExit(exitId, 0, challengeData, contracts.ERC20Predicate.address)
     await predicateTestUtils.assertChallengeBondReceived(challenge, originalBalance)
     predicateTestUtils.assertExitCancelled(challenge.logs[0], exitId)
@@ -268,111 +267,205 @@ contract('Misc Predicates tests', async function(accounts) {
     predicateTestUtils.assertExitCancelled(challenge.logs[0], exitId)
   })
 
-  it('Mallory is challenged with a marketplace tx', async function() {
-    const stakes = {
-      1: web3.utils.toWei('101'),
-      2: web3.utils.toWei('100'),
-      3: web3.utils.toWei('100'),
-      4: web3.utils.toWei('100')
-    }
-    const wallets = generateFirstWallets(mnemonics, Object.keys(stakes).length)
+  describe('Mallory is challenged with a marketplace tx', async function() {
+    let privateKey1, alice, privateKey2, mallory, marketplacePredicate, marketplace
+    before(async function() {
+      const stakes = {
+        1: web3.utils.toWei('101'),
+        2: web3.utils.toWei('100'),
+        3: web3.utils.toWei('100'),
+        4: web3.utils.toWei('100')
+      }
+      const wallets = generateFirstWallets(mnemonics, Object.keys(stakes).length)
 
-    const privateKey1 = wallets[0].getPrivateKeyString()
-    const alice = wallets[0].getAddressString()
+      privateKey1 = wallets[0].getPrivateKeyString()
+      alice = wallets[0].getAddressString()
 
-    const privateKey2 = wallets[1].getPrivateKeyString()
-    const mallory = wallets[1].getAddressString()
+      privateKey2 = wallets[1].getPrivateKeyString()
+      mallory = wallets[1].getAddressString()
 
-    // setup tokens and predicate
-    const erc20 = await deployer.deployChildErc20(accounts[0])
-    const token1 = erc20.childToken
-    const otherErc20 = await deployer.deployChildErc20(accounts[0])
-    const token2 = otherErc20.childToken
-    const marketplacePredicate = await deployer.deployMarketplacePredicate()
-    const marketplace = await deployer.deployMarketplace()
-
-    // These are the amounts that will be used in Marketplace.executeOrder
-    const amount1 = web3.utils.toBN('3')
-    const amount2 = web3.utils.toBN('7')
-
-    // UTXO1A
-    let deposit = await utils.deposit(
-      contracts.depositManager,
-      childContracts.childChain,
-      otherErc20.rootERC20,
-      alice,
-      web3.utils.toBN('13')
-    )
-    const utxo1a = { checkpoint: await statefulUtils.submitCheckpoint(contracts.rootChain, deposit.receipt, accounts), logIndex: 1 }
-
-    // Alice spends UTXO1A in tx1 to Mallory, creating UTXO2M (and UTXO2A)
-    const tx1 = await token2.transfer(mallory, amount2, { from: alice })
-
-    // Mallory starts an exit from TX1 (from UTXO2M) while referencing UTXO1A and places exit bond
-    let startExitTx = await utils.startExitNew(
-      contracts.ERC20Predicate,
-      [utxo1a].map(predicateTestUtils.buildInputFromCheckpoint), // proof-of-funds of counterparty
-      await predicateTestUtils.buildInFlight(await web3Child.eth.getTransaction(tx1.receipt.transactionHash)),
-      mallory // exitor
-    )
-    let logs = logDecoder.decodeLogs(startExitTx.receipt.rawLogs)
-    const ageOfUtxo1a = predicateTestUtils.getAge(utxo1a)
-    let exitId = ageOfUtxo1a.shln(1)
-    await predicateTestUtils.assertStartExit(logs[1], mallory, otherErc20.rootERC20.address, amount2, false /* isRegularExit */, exitId, contracts.exitNFT)
-    predicateTestUtils.assertExitUpdated(logs[2], alice, exitId, ageOfUtxo1a)
-
-    // setup for marketplace swap
-    const depositAmount = amount1.add(web3.utils.toBN('1'))
-    // deposit tokens of another type for a 3rd party (re-using alice here, but not necessary)
-    await utils.deposit(null, childContracts.childChain, erc20.rootERC20, alice, depositAmount)
-
-    assert.equal((await token1.balanceOf(alice)).toNumber(), depositAmount)
-    assert.equal((await token2.balanceOf(mallory)).toNumber(), amount2)
-
-    const orderId = '0x' + crypto.randomBytes(32).toString('hex')
-    // get expiration in future in 10 blocks
-    const expiration = 0 // (await web3.eth.getBlockNumber()) + 10
-    // Alice's sig on marketplace order
-    const obj1 = getSig({
-      privateKey: privateKey1,
-      spender: marketplace.address,
-      orderId: orderId,
-      expiration: expiration,
-
-      token1: token1.address,
-      amount1: amount1,
-      token2: token2.address,
-      amount2: amount2
+      marketplacePredicate = await deployer.deployMarketplacePredicate()
+      marketplace = await deployer.deployMarketplace()
     })
-    // Mallory's sig on marketplace order
-    const obj2 = getSig({
-      privateKey: privateKey2,
-      spender: marketplace.address,
-      orderId: orderId,
-      expiration: expiration,
 
-      token2: token1.address,
-      amount2: amount1,
-      token1: token2.address,
-      amount1: amount2
+    it('erc20/20 swap', async function() {
+      // setup tokens and predicate
+      const erc20 = await deployer.deployChildErc20(accounts[0])
+      const token1 = erc20.childToken
+      const otherErc20 = await deployer.deployChildErc20(accounts[0])
+      const token2 = otherErc20.childToken
+
+      // These are the amounts that will be used in Marketplace.executeOrder
+      const amount1 = web3.utils.toBN('3')
+      const amount2 = web3.utils.toBN('7')
+
+      // UTXO1A
+      let deposit = await utils.deposit(
+        contracts.depositManager,
+        childContracts.childChain,
+        otherErc20.rootERC20,
+        alice,
+        web3.utils.toBN('13')
+      )
+      const utxo1a = { checkpoint: await statefulUtils.submitCheckpoint(contracts.rootChain, deposit.receipt, accounts), logIndex: 1 }
+
+      // Alice spends UTXO1A in tx1 to Mallory, creating UTXO2M (and UTXO2A)
+      const tx1 = await token2.transfer(mallory, amount2, { from: alice })
+
+      // Mallory starts an exit from TX1 (from UTXO2M) while referencing UTXO1A and places exit bond
+      let startExitTx = await utils.startExitNew(
+        contracts.ERC20Predicate,
+        [utxo1a].map(predicateTestUtils.buildInputFromCheckpoint), // proof-of-funds of counterparty
+        await predicateTestUtils.buildInFlight(await web3Child.eth.getTransaction(tx1.receipt.transactionHash)),
+        mallory // exitor
+      )
+      let logs = logDecoder.decodeLogs(startExitTx.receipt.rawLogs)
+      const ageOfUtxo1a = predicateTestUtils.getAge(utxo1a)
+      let exitId = ageOfUtxo1a.shln(1)
+      await predicateTestUtils.assertStartExit(logs[1], mallory, otherErc20.rootERC20.address, amount2, false /* isRegularExit */, exitId, contracts.exitNFT)
+      predicateTestUtils.assertExitUpdated(logs[2], alice, exitId, ageOfUtxo1a)
+
+      // setup for marketplace swap
+      const depositAmount = amount1.add(web3.utils.toBN('1'))
+      // deposit tokens of another type for a 3rd party (re-using alice here, but not necessary)
+      await utils.deposit(null, childContracts.childChain, erc20.rootERC20, alice, depositAmount)
+
+      assert.equal((await token1.balanceOf(alice)).toNumber(), depositAmount)
+      assert.equal((await token2.balanceOf(mallory)).toNumber(), amount2)
+
+      const orderId = '0x' + crypto.randomBytes(32).toString('hex')
+      // get expiration in future in 10 blocks
+      const expiration = 0 // (await web3.eth.getBlockNumber()) + 10
+      // Alice's sig on marketplace order
+      const obj1 = getSig({
+        privateKey: privateKey1,
+        spender: marketplace.address,
+        orderId: orderId,
+        expiration: expiration,
+
+        token1: token1.address,
+        amount1: amount1,
+        token2: token2.address,
+        amount2: amount2
+      })
+      // Mallory's sig on marketplace order
+      const obj2 = getSig({
+        privateKey: privateKey2,
+        spender: marketplace.address,
+        orderId: orderId,
+        expiration: expiration,
+
+        token2: token1.address,
+        amount2: amount1,
+        token1: token2.address,
+        amount1: amount2
+      })
+      const tx2 = await marketplace.executeOrder(
+        encode(token1.address, obj1.sig, amount1),
+        encode(token2.address, obj2.sig, amount2),
+        orderId,
+        expiration,
+        mallory
+      )
+      // logIndex = 3 because token2 was the second token transfer in executeOrder
+      const utxo3m = { checkpoint: await statefulUtils.submitCheckpoint(contracts.rootChain, tx2.receipt, accounts), logIndex: 3 }
+
+      // During the challenge period, the challenger reveals TX2 and receives exit bond
+      const challengeData = utils.buildChallengeData(predicateTestUtils.buildInputFromCheckpoint(utxo3m))
+      // This will be used to assert that challenger received the bond amount
+      const originalBalance = web3.utils.toBN(await web3.eth.getBalance(accounts[0]))
+      const challenge = await contracts.withdrawManager.challengeExit(exitId, 0, challengeData, marketplacePredicate.address)
+      await predicateTestUtils.assertChallengeBondReceived(challenge, originalBalance)
+      predicateTestUtils.assertExitCancelled(challenge.logs[0], exitId)
     })
-    const tx2 = await marketplace.executeOrder(
-      encode(token1.address, obj1.sig, amount1),
-      encode(token2.address, obj2.sig, amount2),
-      orderId,
-      expiration,
-      mallory
-    )
-    // logIndex = 3 because token2 was the second token transfer in executeOrder
-    const utxo3m = { checkpoint: await statefulUtils.submitCheckpoint(contracts.rootChain, tx2.receipt, accounts), logIndex: 3 }
 
-    // During the challenge period, the challenger reveals TX2 and receives exit bond
-    const challengeData = utils.buildChallengeData(predicateTestUtils.buildInputFromCheckpoint(utxo3m))
-    // This will be used to assert that challenger received the bond amount
-    const originalBalance = web3.utils.toBN(await web3.eth.getBalance(accounts[0]))
-    const challenge = await contracts.withdrawManager.challengeExit(exitId, 0, challengeData, marketplacePredicate.address)
-    await predicateTestUtils.assertChallengeBondReceived(challenge, originalBalance)
-    predicateTestUtils.assertExitCancelled(challenge.logs[0], exitId)
+    it('erc20/721 swap', async function() {
+      const amount1 = web3.utils.toBN('10')
+      const tokenId = web3.utils.toBN('789')
+
+      const erc20 = await deployer.deployChildErc20(accounts[0])
+      const token1 = erc20.childToken
+      const erc721 = await deployer.deployChildErc721(accounts[0])
+      const token2 = erc721.childErc721
+
+      // const depositAmount = amount1.add(web3.utils.toBN('3'))
+      let deposit = await utils.deposit(
+        contracts.depositManager,
+        childContracts.childChain,
+        erc721.rootERC721,
+        alice,
+        tokenId
+      )
+      const utxo1a = { checkpoint: await statefulUtils.submitCheckpoint(contracts.rootChain, deposit.receipt, accounts), logIndex: 1 }
+
+      const tx1 = await token2.transferFrom(alice, mallory, tokenId, { from: alice })
+      const ERC721Predicate = await deployer.deployErc721Predicate()
+      const startExitTx = await utils.startExitNew(
+        ERC721Predicate,
+        [utxo1a].map(predicateTestUtils.buildInputFromCheckpoint), // proof-of-funds of counterparty
+        await predicateTestUtils.buildInFlight(await web3Child.eth.getTransaction(tx1.receipt.transactionHash)),
+        mallory // exitor
+      )
+      let logs = logDecoder.decodeLogs(startExitTx.receipt.rawLogs)
+      let ageOfUtxo1a = predicateTestUtils.getAge(utxo1a)
+      let exitId = ageOfUtxo1a.shln(1)
+      await predicateTestUtils.assertStartExit(logs[1], mallory, erc721.rootERC721.address, tokenId, false /* isRegularExit */, exitId, contracts.exitNFT)
+      predicateTestUtils.assertExitUpdated(logs[2], alice, exitId, ageOfUtxo1a)
+
+      deposit = await utils.deposit(
+        contracts.depositManager,
+        childContracts.childChain,
+        erc20.rootERC20,
+        alice,
+        amount1
+      )
+
+      assert.equal((await token1.balanceOf(alice)).toNumber(), amount1)
+      assert.equal((await token2.ownerOf(tokenId)).toLowerCase(), mallory.toLowerCase())
+
+      const orderId = '0x' + crypto.randomBytes(32).toString('hex')
+      // get expiration in future in 10 blocks
+      const expiration = 0 // (await web3.eth.getBlockNumber()) + 10
+      const obj1 = getSig({
+        privateKey: privateKey1,
+        spender: marketplace.address,
+        orderId: orderId,
+        expiration: expiration,
+
+        token1: token1.address,
+        amount1: amount1,
+        token2: token2.address,
+        amount2: tokenId
+      })
+      const obj2 = getSig({
+        privateKey: privateKey2,
+        spender: marketplace.address,
+        orderId: orderId,
+        expiration: expiration,
+
+        token2: token1.address,
+        amount2: amount1,
+        token1: token2.address,
+        amount1: tokenId
+      })
+      const tx2 = await marketplace.executeOrder(
+        encode(token1.address, obj1.sig, amount1),
+        encode(token2.address, obj2.sig, tokenId),
+        orderId,
+        expiration,
+        mallory
+      )
+      // logIndex = 3 because token2 was the second token transfer in executeOrder
+      const utxo3m = { checkpoint: await statefulUtils.submitCheckpoint(contracts.rootChain, tx2.receipt, accounts), logIndex: 3 }
+
+      // During the challenge period, the challenger reveals TX2 and receives exit bond
+      const challengeData = utils.buildChallengeData(predicateTestUtils.buildInputFromCheckpoint(utxo3m))
+      // This will be used to assert that challenger received the bond amount
+      const originalBalance = web3.utils.toBN(await web3.eth.getBalance(accounts[0]))
+      const challenge = await contracts.withdrawManager.challengeExit(exitId, ageOfUtxo1a.sub(web3.utils.toBN(1)), challengeData, marketplacePredicate.address)
+      await predicateTestUtils.assertChallengeBondReceived(challenge, originalBalance)
+      predicateTestUtils.assertExitCancelled(challenge.logs[0], exitId)
+    })
   })
 })
 

--- a/test/root/ExitScenarios.test.js
+++ b/test/root/ExitScenarios.test.js
@@ -121,6 +121,7 @@ contract('Misc Predicates tests', async function(accounts) {
     // Mallory spends UTXO2M in TX2 creating UTXO3M
     const tx2 = await childErc20.transfer('0x' + crypto.randomBytes(20).toString('hex'), web3.utils.toBN('5'), { from: mallory })
     const utxo3m = { checkpoint: await statefulUtils.submitCheckpoint(contracts.rootChain, tx2.receipt, accounts), logIndex: 1 }
+
     // Mallory starts an exit from TX1 (from UTXO2M) while referencing UTXO1A and places exit bond
     let startExitTx = await utils.startExitNew(
       contracts.ERC20Predicate,
@@ -138,7 +139,8 @@ contract('Misc Predicates tests', async function(accounts) {
     const challengeData = utils.buildChallengeData(predicateTestUtils.buildInputFromCheckpoint(utxo3m))
     // This will be used to assert that challenger received the bond amount
     const originalBalance = web3.utils.toBN(await web3.eth.getBalance(accounts[0]))
-    const challenge = await contracts.withdrawManager.challengeExit(exitId, ageOfUtxo1a, challengeData)
+    // const challenge = await contracts.withdrawManager.challengeExit(exitId, ageOfUtxo1a, challengeData, contracts.ERC20Predicate.address)
+    const challenge = await contracts.withdrawManager.challengeExit(exitId, 0, challengeData, contracts.ERC20Predicate.address)
     await predicateTestUtils.assertChallengeBondReceived(challenge, originalBalance)
     predicateTestUtils.assertExitCancelled(challenge.logs[0], exitId)
   })
@@ -201,7 +203,7 @@ contract('Misc Predicates tests', async function(accounts) {
     const challengeData = utils.buildChallengeData(predicateTestUtils.buildInputFromCheckpoint(_utxo2A))
     // This will be used to assert that challenger received the bond amount
     const originalBalance = web3.utils.toBN(await web3.eth.getBalance(accounts[0]))
-    const challenge = await contracts.withdrawManager.challengeExit(exitId, ageOfUtxo1a, challengeData)
+    const challenge = await contracts.withdrawManager.challengeExit(exitId, ageOfUtxo1a, challengeData, contracts.ERC20Predicate.address)
     await predicateTestUtils.assertChallengeBondReceived(challenge, originalBalance)
     predicateTestUtils.assertExitCancelled(challenge.logs[0], exitId)
   })
@@ -249,7 +251,7 @@ contract('Misc Predicates tests', async function(accounts) {
     // challenging with the exit tx itself should fail
     try {
       const challengeData = utils.buildChallengeData(predicateTestUtils.buildInputFromCheckpoint(_utxo2A))
-      await contracts.withdrawManager.challengeExit(exitId, ageOfUtxo1a, challengeData)
+      await contracts.withdrawManager.challengeExit(exitId, ageOfUtxo1a, challengeData, contracts.ERC20Predicate.address)
       assert.fail('Challenge should have failed')
     } catch(e) {
       assert.strictEqual(e.reason, 'Cannot challenge with the exit tx')
@@ -259,7 +261,7 @@ contract('Misc Predicates tests', async function(accounts) {
     const challengeData = utils.buildChallengeData(predicateTestUtils.buildInputFromCheckpoint(utxo2A))
     // This will be used to assert that challenger received the bond amount
     const originalBalance = web3.utils.toBN(await web3.eth.getBalance(accounts[0]))
-    const challenge = await contracts.withdrawManager.challengeExit(exitId, ageOfUtxo1a, challengeData)
+    const challenge = await contracts.withdrawManager.challengeExit(exitId, ageOfUtxo1a, challengeData, contracts.ERC20Predicate.address)
     await predicateTestUtils.assertChallengeBondReceived(challenge, originalBalance)
     predicateTestUtils.assertExitCancelled(challenge.logs[0], exitId)
   })

--- a/test/root/WithdrawManager.test.js
+++ b/test/root/WithdrawManager.test.js
@@ -8,7 +8,7 @@ const predicateTestUtils = require('./predicates/predicateTestUtils')
 const utils = require('../helpers/utils')
 
 chai.use(chaiAsPromised).should()
-let contracts, childContracts, statefulUtils
+let contracts, childContracts, statefulUtils, erc20Predicate
 
 contract('WithdrawManager', async function(accounts) {
   const amount = web3.utils.toBN('10')
@@ -20,7 +20,7 @@ contract('WithdrawManager', async function(accounts) {
     before(async function() {
       contracts = await deployer.freshDeploy()
       statefulUtils = new StatefulUtils()
-      await deployer.deployErc20Predicate()
+      erc20Predicate = await deployer.deployErc20Predicate()
       childContracts = await deployer.initializeChildChain(owner)
       const { rootERC20, childToken } = await deployer.deployChildErc20(owner)
       contracts.rootERC20 = rootERC20
@@ -61,7 +61,7 @@ contract('WithdrawManager', async function(accounts) {
       const challengeData = utils.buildChallengeData(predicateTestUtils.buildInputFromCheckpoint(utxo))
       // This will be used to assert that challenger received the bond amount
       const originalBalance = web3.utils.toBN(await web3.eth.getBalance(owner))
-      const challenge = await contracts.withdrawManager.challengeExit(exitId, ageOfInput, challengeData)
+      const challenge = await contracts.withdrawManager.challengeExit(exitId, ageOfInput, challengeData, erc20Predicate.address)
       await predicateTestUtils.assertChallengeBondReceived(challenge, originalBalance)
       log = challenge.logs[0]
       log.event.should.equal('ExitCancelled')

--- a/test/root/predicates/ERC721Predicate.test.js
+++ b/test/root/predicates/ERC721Predicate.test.js
@@ -211,7 +211,7 @@ contract('ERC721Predicate', async function(accounts) {
       const challengeData = utils.buildChallengeData(predicateTestUtils.buildInputFromCheckpoint(spendUtxo))
       // This will be used to assert that challenger received the bond amount
       const originalBalance = web3.utils.toBN(await web3.eth.getBalance(accounts[0]))
-      const challenge = await contracts.withdrawManager.challengeExit(exitId, ageOfUtxo1a, challengeData)
+      const challenge = await contracts.withdrawManager.challengeExit(exitId, ageOfUtxo1a, challengeData, contracts.ERC721Predicate.address)
       await predicateTestUtils.assertChallengeBondReceived(challenge, originalBalance)
       const log = challenge.logs[0]
       log.event.should.equal('ExitCancelled')
@@ -259,7 +259,7 @@ contract('ERC721Predicate', async function(accounts) {
       const challengeData = utils.buildChallengeData(predicateTestUtils.buildInputFromCheckpoint(spendUtxo))
       // This will be used to assert that challenger received the bond amount
       const originalBalance = web3.utils.toBN(await web3.eth.getBalance(accounts[0]))
-      const challenge = await contracts.withdrawManager.challengeExit(exitId, ageOfUtxo1a, challengeData)
+      const challenge = await contracts.withdrawManager.challengeExit(exitId, ageOfUtxo1a, challengeData, contracts.ERC721Predicate.address)
       await predicateTestUtils.assertChallengeBondReceived(challenge, originalBalance)
       predicateTestUtils.assertExitCancelled(challenge.logs[0], exitId)
     })

--- a/test/root/predicates/ERC721Predicate.test.js
+++ b/test/root/predicates/ERC721Predicate.test.js
@@ -211,7 +211,7 @@ contract('ERC721Predicate', async function(accounts) {
       const challengeData = utils.buildChallengeData(predicateTestUtils.buildInputFromCheckpoint(spendUtxo))
       // This will be used to assert that challenger received the bond amount
       const originalBalance = web3.utils.toBN(await web3.eth.getBalance(accounts[0]))
-      const challenge = await contracts.withdrawManager.challengeExit(exitId, ageOfUtxo1a, challengeData, contracts.ERC721Predicate.address)
+      const challenge = await contracts.withdrawManager.challengeExit(exitId, ageOfUtxo1a.sub(web3.utils.toBN(1)), challengeData, contracts.ERC721Predicate.address)
       await predicateTestUtils.assertChallengeBondReceived(challenge, originalBalance)
       const log = challenge.logs[0]
       log.event.should.equal('ExitCancelled')

--- a/test/root/predicates/MarketplacePredicate.test.js
+++ b/test/root/predicates/MarketplacePredicate.test.js
@@ -119,7 +119,6 @@ contract('MarketplacePredicate', async function(accounts) {
     log.event.should.equal('ExitUpdated')
     assert.equal(log.args.signer.toLowerCase(), address1.toLowerCase())
     utils.assertBigNumberEquality(log.args.exitId, exitId)
-    const age = log.args.age
 
     log = logs[3]
     log.event.should.equal('ExitUpdated')
@@ -195,7 +194,6 @@ contract('MarketplacePredicate', async function(accounts) {
     log.event.should.equal('ExitUpdated')
     assert.equal(log.args.signer.toLowerCase(), address1.toLowerCase())
     utils.assertBigNumberEquality(log.args.exitId, exitId)
-    const age = log.args.age
 
     log = logs[3]
     log.event.should.equal('ExitUpdated')

--- a/test/root/predicates/MarketplacePredicateUnit.test.js
+++ b/test/root/predicates/MarketplacePredicateUnit.test.js
@@ -30,15 +30,15 @@ contract('MarketplacePredicate (from mocked responses)', async function(accounts
     predicate = await artifacts.MarketplacePredicateTest.deployed()
   })
 
-  it('processPreState (Erc20 Deposit)', async function() {
+  it('processLogTransferReceipt (Erc20 Deposit)', async function() {
     let event = deposit1
-    let processPreState = await predicate.processPreStateTest(
+    let processLogTransferReceipt = await predicate.processLogTransferReceiptTest(
       erc20Predicate.address,
       ethUtils.bufferToHex(ethUtils.rlp.encode(dummyReferenceData(event, 1))),
       '0x9fb29aac15b9a4b7f17c3385939b007540f4d791'
     )
-    // console.log('processPreState', processPreState)
-    let ans = processPreState.slice(2)
+    // console.log('processLogTransferReceipt', processLogTransferReceipt)
+    let ans = processLogTransferReceipt.slice(2)
     let input = event.receipt.logs[1]
     assert.equal(parseInt(ans.slice(0, 64), 16), parseInt(input.data.slice(-64), 16))
     assert.equal(parseInt(ans.slice(64, 128), 16), 1 * 10 /* logIndex * MAX_LOGS */)
@@ -46,13 +46,13 @@ contract('MarketplacePredicate (from mocked responses)', async function(accounts
     assert.equal(ans.slice(192, 256).slice(24).toLowerCase(), input.topics[1].slice(26).toLowerCase())
 
     event = deposit2
-    processPreState = await predicate.processPreStateTest(
+    processLogTransferReceipt = await predicate.processLogTransferReceiptTest(
       erc20Predicate.address,
       ethUtils.bufferToHex(ethUtils.rlp.encode(dummyReferenceData(event, 1))),
       '0x96c42c56fdb78294f96b0cfa33c92bed7d75f96a'
     )
-    // console.log('processPreState', processPreState)
-    ans = processPreState.slice(2)
+    // console.log('processLogTransferReceipt', processLogTransferReceipt)
+    ans = processLogTransferReceipt.slice(2)
     input = event.receipt.logs[1]
     assert.equal(parseInt(ans.slice(0, 64), 16), parseInt(input.data.slice(-64), 16))
     assert.equal(parseInt(ans.slice(64, 128), 16), 1 * 10 /* logIndex * MAX_LOGS */)
@@ -60,15 +60,15 @@ contract('MarketplacePredicate (from mocked responses)', async function(accounts
     assert.equal(ans.slice(192, 256).slice(24).toLowerCase(), input.topics[1].slice(26).toLowerCase())
   })
 
-  it('processPreState (Erc20 outgoingTransfer)', async function() {
+  it('processLogTransferReceipt (Erc20 outgoingTransfer)', async function() {
     let event = incomingTransfer
-    let processPreState = await predicate.processPreStateTest(
+    let processLogTransferReceipt = await predicate.processLogTransferReceiptTest(
       erc20Predicate.address,
       ethUtils.bufferToHex(ethUtils.rlp.encode(dummyReferenceData(event, 1))),
       '0x96c42c56fdb78294f96b0cfa33c92bed7d75f96a'
     )
-    // console.log('processPreState', processPreState)
-    let ans = processPreState.slice(2)
+    // console.log('processLogTransferReceipt', processLogTransferReceipt)
+    let ans = processLogTransferReceipt.slice(2)
     let input = event.receipt.logs[1]
     assert.equal(parseInt(ans.slice(0, 64), 16), parseInt(input.data.slice(-128, -64) /* output1 */, 16))
     assert.equal(parseInt(ans.slice(64, 128), 16), 1 * 10 /* logIndex * MAX_LOGS */)
@@ -76,15 +76,15 @@ contract('MarketplacePredicate (from mocked responses)', async function(accounts
     assert.equal(ans.slice(192, 256).slice(24).toLowerCase(), input.topics[1].slice(26).toLowerCase())
   })
 
-  it('processPreState (Erc20 incomingTransfer)', async function() {
+  it('processLogTransferReceipt (Erc20 incomingTransfer)', async function() {
     let event = incomingTransfer
-    let processPreState = await predicate.processPreStateTest(
+    let processLogTransferReceipt = await predicate.processLogTransferReceiptTest(
       erc20Predicate.address,
       ethUtils.bufferToHex(ethUtils.rlp.encode(dummyReferenceData(event, 1))),
       '0x9fb29aac15b9a4b7f17c3385939b007540f4d791'
     )
-    // console.log('processPreState', processPreState)
-    let ans = processPreState.slice(2)
+    // console.log('processLogTransferReceipt', processLogTransferReceipt)
+    let ans = processLogTransferReceipt.slice(2)
     let input = event.receipt.logs[1]
     assert.equal(parseInt(ans.slice(0, 64), 16), parseInt(input.data.slice(-64) /* output2 */, 16))
     assert.equal(parseInt(ans.slice(64, 128), 16), 1 * 10 + 1 /* logIndex * MAX_LOGS + oIndex */)
@@ -92,15 +92,15 @@ contract('MarketplacePredicate (from mocked responses)', async function(accounts
     assert.equal(ans.slice(192, 256).slice(24).toLowerCase(), input.topics[1].slice(26).toLowerCase())
   })
 
-  it('processPreState (Erc721 Deposit)', async function() {
+  it('processLogTransferReceipt (Erc721 Deposit)', async function() {
     let event = erc20_721_Deposit_1
-    let processPreState = await predicate.processPreStateTest(
+    let processLogTransferReceipt = await predicate.processLogTransferReceiptTest(
       erc20Predicate.address,
       ethUtils.bufferToHex(ethUtils.rlp.encode(dummyReferenceData(event, 1))),
       '0x9fb29aac15b9a4b7f17c3385939b007540f4d791'
     )
-    // console.log('processPreState', processPreState)
-    let ans = processPreState.slice(2)
+    // console.log('processLogTransferReceipt', processLogTransferReceipt)
+    let ans = processLogTransferReceipt.slice(2)
     let input = event.receipt.logs[1]
     assert.equal(parseInt(ans.slice(0, 64), 16), parseInt(input.data.slice(-64), 16))
     assert.equal(parseInt(ans.slice(64, 128), 16), 1 * 10 /* logIndex * MAX_LOGS */)
@@ -108,13 +108,13 @@ contract('MarketplacePredicate (from mocked responses)', async function(accounts
     assert.equal(ans.slice(192, 256).slice(24).toLowerCase(), input.topics[1].slice(26).toLowerCase())
 
     event = erc20_721_Deposit_2
-    processPreState = await predicate.processPreStateTest(
+    processLogTransferReceipt = await predicate.processLogTransferReceiptTest(
       erc721Predicate.address,
       ethUtils.bufferToHex(ethUtils.rlp.encode(dummyReferenceData(event, 1))),
       '0x96c42c56fdb78294f96b0cfa33c92bed7d75f96a'
     )
-    // console.log('processPreState', processPreState)
-    ans = processPreState.slice(2)
+    // console.log('processLogTransferReceipt', processLogTransferReceipt)
+    ans = processLogTransferReceipt.slice(2)
     input = event.receipt.logs[1]
     assert.equal(parseInt(ans.slice(0, 64), 16), parseInt(input.data.slice(-64), 16))
     assert.equal(parseInt(ans.slice(64, 128), 16), 1 * 10 /* logIndex * MAX_LOGS */)

--- a/test/root/predicates/predicateTestUtils.js
+++ b/test/root/predicates/predicateTestUtils.js
@@ -48,19 +48,23 @@ export function buildInFlight(tx) {
 }
 
 export async function assertStartExit(log, exitor, token, amount, isRegularExit, exitId, exitNFT) {
+  exitor = exitor.toLowerCase()
+  token = token.toLowerCase()
   log.event.should.equal('ExitStarted')
-  expect(log.args).to.include({ exitor, token, isRegularExit })
+  assert.strictEqual(log.args.exitor.toLowerCase(), exitor)
+  assert.strictEqual(log.args.token.toLowerCase(), token)
+  expect(log.args).to.include({ isRegularExit })
   utils.assertBigNumberEquality(log.args.amount, amount)
   if (exitId) {
     // console.log('in assertStartExit: exitId', log.args.exitId, exitId.toString(16))
     utils.assertBigNumberEquality(log.args.exitId, exitId)
-    if (exitNFT) assert.strictEqual(await exitNFT.ownerOf(exitId), exitor)
+    if (exitNFT) assert.strictEqual((await exitNFT.ownerOf(exitId)).toLowerCase(), exitor)
   }
 }
 
 export function assertExitUpdated(log, signer, exitId, ageOfUtxo) {
   log.event.should.equal('ExitUpdated')
-  expect(log.args).to.include({ signer })
+  assert.strictEqual(log.args.signer.toLowerCase(), signer.toLowerCase())
   // console.log('in assertExitUpdated: exitId', log.args.exitId, exitId.toString(16))
   utils.assertBigNumberEquality(log.args.exitId, exitId)
   // console.log('in assertExitUpdated: ageOfUtxo', log.args.age, ageOfUtxo.toString(16))


### PR DESCRIPTION
1. `MarketplacePredicate.verifyDeprecation()` - With this change, marketplace txs become a valid spend i.e. it is possible to challenge an exit with a marketplace tx. Interestingly, this makes a call to `erc20/721Predicate.interpretStateUpdate()` to process the `LogTransfer` receipt.

2. Add `address adjudicatorPredicate` param in `challengeExit`.
This is required because predicate that evaluates the challenge maybe different from the predicate from which the exit was started. For instance, exit may have been started by calling `ERC20Predicate.startExit()` but the challenge could entail invoking `MarketplacePredicate.verifyDeprecation()`.

3. Move `address predicate` field from `PlasmaExit` to inside `Input` in `ExitsDataStructure`.

4. Bunch of other refactoring.