### PR TITLE
Staking cleanups

### DIFF
--- a/contracts/root/RootChain.sol
+++ b/contracts/root/RootChain.sol
@@ -47,9 +47,9 @@ contract RootChain is RootChainStorage, IRootChain {
     headerBlocks[_nextHeaderBlock] = headerBlock;
     // check if it is better to keep it in local storage instead
     IStakeManager stakeManager = IStakeManager(registry.getStakeManagerAddress());
-    stakeManager.checkSignatures(headerBlock.end.sub(headerBlock.start), keccak256(vote), bytes32(extraData[4].toUint()), sigs);
+    uint256 _reward = stakeManager.checkSignatures(headerBlock.end.sub(headerBlock.start), keccak256(vote), bytes32(extraData[4].toUint()), sigs);
 
-    emit NewHeaderBlock(headerBlock.proposer, _nextHeaderBlock, headerBlock.start, headerBlock.end, headerBlock.root);
+    emit NewHeaderBlock(headerBlock.proposer, _nextHeaderBlock, _reward, headerBlock.start, headerBlock.end, headerBlock.root);
     _nextHeaderBlock = _nextHeaderBlock.add(MAX_DEPOSITS);
     _blockDepositId = 1;
   }

--- a/contracts/root/RootChain.sol
+++ b/contracts/root/RootChain.sol
@@ -47,7 +47,7 @@ contract RootChain is RootChainStorage, IRootChain {
     headerBlocks[_nextHeaderBlock] = headerBlock;
     // check if it is better to keep it in local storage instead
     IStakeManager stakeManager = IStakeManager(registry.getStakeManagerAddress());
-    stakeManager.checkSignatures(keccak256(vote), bytes32(extraData[4].toUint()), sigs);
+    stakeManager.checkSignatures(headerBlock.end.sub(headerBlock.start), keccak256(vote), bytes32(extraData[4].toUint()), sigs);
 
     emit NewHeaderBlock(headerBlock.proposer, _nextHeaderBlock, headerBlock.start, headerBlock.end, headerBlock.root);
     _nextHeaderBlock = _nextHeaderBlock.add(MAX_DEPOSITS);
@@ -104,10 +104,6 @@ contract RootChain is RootChainStorage, IRootChain {
     );
     headerBlock.start = nextChildBlock;
     headerBlock.end = dataList[2].toUint();
-    require(
-      headerBlock.end >= headerBlock.start,
-      "NOT_ADDING_BLOCKS"
-    );
 
     // toUintStrict returns the encoded uint. Encoded data must be padded to 32 bytes.
     headerBlock.root = bytes32(dataList[3].toUintStrict());

--- a/contracts/root/RootChainStorage.sol
+++ b/contracts/root/RootChainStorage.sol
@@ -3,10 +3,12 @@ pragma solidity ^0.5.2;
 import { Registry } from "../common/Registry.sol";
 import { ProxyStorage } from "../common/misc/ProxyStorage.sol";
 
+
 contract RootChainHeader {
   event NewHeaderBlock(
     address indexed proposer,
     uint256 indexed headerBlockId,
+    uint256 indexed reward,
     uint256 start,
     uint256 end,
     bytes32 root

--- a/contracts/staking/IStakeManager.sol
+++ b/contracts/staking/IStakeManager.sol
@@ -30,7 +30,7 @@ contract IStakeManager {
   function totalStakedFor(address addr) external view returns (uint256);
   function supportsHistory() external pure returns (bool);
   function stakeFor(address user, uint256 amount, address signer, bool isContract) public;
-  function checkSignatures(uint256 blockInterval, bytes32 voteHash, bytes32 stateRoot, bytes memory sigs) public;
+  function checkSignatures(uint256 blockInterval, bytes32 voteHash, bytes32 stateRoot, bytes memory sigs) public returns(uint256);
   function updateValidatorState(uint256 validatorId, uint256 epoch, int256 amount) public;
 
   // optional

--- a/contracts/staking/IStakeManager.sol
+++ b/contracts/staking/IStakeManager.sol
@@ -30,7 +30,7 @@ contract IStakeManager {
   function totalStakedFor(address addr) external view returns (uint256);
   function supportsHistory() external pure returns (bool);
   function stakeFor(address user, uint256 amount, address signer, bool isContract) public;
-  function checkSignatures(bytes32 voteHash, bytes32 stateRoot, bytes memory sigs) public;
+  function checkSignatures(uint256 blockInterval, bytes32 voteHash, bytes32 stateRoot, bytes memory sigs) public;
   function updateValidatorState(uint256 validatorId, uint256 epoch, int256 amount) public;
 
   // optional

--- a/contracts/staking/StakeManager.sol
+++ b/contracts/staking/StakeManager.sol
@@ -146,8 +146,11 @@ contract StakeManager is Validator, IStakeManager, RootChainable, Lockable {
     // when dynasty period is updated validators are in cool down period
     require(replacementCoolDown == 0 || replacementCoolDown <= currentEpoch, "Cool down period");
     require(auctionPeriod >= currentEpoch.sub(validatorAuction[validatorId].startEpoch), "Invalid auction period");
-    // dynasty--auctionPeriod--dynasty--auctionPeriod--dynasty
+    // (dynasty--auctionPeriod)--(dynasty--auctionPeriod)--(dynasty--auctionPeriod)
+    // if it's auctionPeriod then will get residue from (CurrentPeriod of validator )%(dynasty--auctionPeriod)
     // make sure that its `auctionPeriod` window
+    // dynasty = 30, auctionPeriod = 7, activationEpoch = 1, currentEpoch = 39
+    // residue 1 = (39-1)% (30+7), if residue-dynasty  > 0 it's `auctionPeriod`
     require((currentEpoch.sub(validators[validatorId].activationEpoch) % dynasty.add(auctionPeriod)) > dynasty, "Not an auction time");
 
     require(token.transferFrom(msg.sender, address(this), amount), "Transfer amount failed");

--- a/contracts/staking/StakeManager.sol
+++ b/contracts/staking/StakeManager.sol
@@ -508,7 +508,7 @@ contract StakeManager is Validator, IStakeManager, RootChainable, Lockable {
     // eg. checkpointReward = 10 Tokens, checkPointBlockInterval = 250, blockInterval = 500 then reward
     // for this checkpoint is 20 Tokens
     uint256 _reward = checkPointBlockInterval.mul(checkpointReward).div(blockInterval);
-    _reward = Math.max(checkpointReward, _reward.mul(stakePower).div(_totalStake));
+    _reward = Math.min(checkpointReward, _reward).mul(stakePower).div(_totalStake);
     totalRewards = totalRewards.add(_reward);
 
     // update stateMerkleTree root for accounts balance on heimdall chain

--- a/contracts/staking/StakeManager.sol
+++ b/contracts/staking/StakeManager.sol
@@ -148,7 +148,7 @@ contract StakeManager is Validator, IStakeManager, RootChainable, Lockable {
     require(auctionPeriod >= currentEpoch.sub(validatorAuction[validatorId].startEpoch), "Invalid auction period");
     // dynasty--auctionPeriod--dynasty--auctionPeriod--dynasty
     // make sure that its `auctionPeriod` window
-    require((validators[validatorId].activationEpoch % dynasty.add(auctionPeriod)) > dynasty, "Not an auction time");
+    require((currentEpoch.sub(validators[validatorId].activationEpoch) % dynasty.add(auctionPeriod)) > dynasty, "Not an auction time");
 
     require(token.transferFrom(msg.sender, address(this), amount), "Transfer amount failed");
 

--- a/contracts/staking/StakeManager.sol
+++ b/contracts/staking/StakeManager.sol
@@ -502,6 +502,7 @@ contract StakeManager is Validator, IStakeManager, RootChainable, Lockable {
   function checkSignatures(uint256 blockInterval, bytes32 voteHash, bytes32 stateRoot, bytes memory sigs) public onlyRootChain returns(uint256) {
     uint256 stakePower;
     uint256 _totalStake;
+    (stakePower, _totalStake) = checkTwoByThreeMajority(voteHash, sigs);
     // checkpoint rewards are based on BlockInterval multiplied on `checkpointReward`
     // with actual `blockInterval`
     // eg. checkpointReward = 10 Tokens, checkPointBlockInterval = 250, blockInterval = 500 then reward
@@ -510,7 +511,6 @@ contract StakeManager is Validator, IStakeManager, RootChainable, Lockable {
     _reward = Math.max(checkpointReward, _reward.mul(stakePower).div(_totalStake));
     totalRewards = totalRewards.add(_reward);
 
-    (stakePower, _totalStake) = checkTwoByThreeMajority(voteHash, sigs);
     // update stateMerkleTree root for accounts balance on heimdall chain
     // for previous checkpoint rewards
     accountStateRoot = stateRoot;

--- a/contracts/staking/StakeManager.sol
+++ b/contracts/staking/StakeManager.sol
@@ -499,7 +499,7 @@ contract StakeManager is Validator, IStakeManager, RootChainable, Lockable {
   function checkSignatures(uint256 blockInterval, bytes32 voteHash, bytes32 stateRoot, bytes memory sigs) public onlyRootChain {
     uint256 stakePower;
     uint256 _totalStake;
-    require(checkPointBlockInterval <= blockInterval,"Smaller checkpoint not allowed");
+    require(checkPointBlockInterval <= blockInterval, "Smaller checkpoint not allowed");
 
     (stakePower, _totalStake) = checkTwoByThreeMajority(voteHash, sigs);
     // update stateMerkleTree root for accounts balance on heimdall chain

--- a/contracts/test/StakeManagerTest.sol
+++ b/contracts/test/StakeManagerTest.sol
@@ -12,7 +12,7 @@ contract StakeManagerTest is StakeManager {
     checkPointBlockInterval = 1;
   }
 
-  function checkSignatures(bytes32 voteHash, bytes32 stateRoot, bytes memory sigs) public onlyRootChain {
+  function checkSignatures(uint256 blockInterval, bytes32 voteHash, bytes32 stateRoot, bytes memory sigs) public onlyRootChain {
     return;
   }
 }

--- a/contracts/test/StakeManagerTest.sol
+++ b/contracts/test/StakeManagerTest.sol
@@ -9,6 +9,7 @@ contract StakeManagerTest is StakeManager {
   }
 
   constructor (address _registry, address _rootChain) StakeManager(_registry, _rootChain) public {
+    checkPointBlockInterval = 1;
   }
 
   function checkSignatures(bytes32 voteHash, bytes32 stateRoot, bytes memory sigs) public onlyRootChain {

--- a/contracts/test/StakeManagerTest.sol
+++ b/contracts/test/StakeManagerTest.sol
@@ -12,7 +12,7 @@ contract StakeManagerTest is StakeManager {
     checkPointBlockInterval = 1;
   }
 
-  function checkSignatures(uint256 blockInterval, bytes32 voteHash, bytes32 stateRoot, bytes memory sigs) public onlyRootChain {
-    return;
+  function checkSignatures(uint256 blockInterval, bytes32 voteHash, bytes32 stateRoot, bytes memory sigs) public onlyRootChain returns(uint256) {
+    return checkpointReward; // for dummy tests return full reward
   }
 }

--- a/test/helpers/utils.js
+++ b/test/helpers/utils.js
@@ -21,7 +21,8 @@ export const web3Child = new web3.constructor(
 )
 
 export const ZeroAddress = '0x0000000000000000000000000000000000000000'
-export const ChildMaticTokenAddress = '0x0000000000000000000000000000000000001010'
+export const ChildMaticTokenAddress =
+  '0x0000000000000000000000000000000000001010'
 export const scalingFactor = web3.utils.toBN(10).pow(web3.utils.toBN(18))
 
 export function getSigs(wallets, votedata) {
@@ -51,6 +52,7 @@ export async function checkPoint(wallets, proposer, stakeManager) {
   const stateRoot = ethUtils.bufferToHex(ethUtils.keccak256('stateRoot'))
   // 2/3 majority vote
   await stakeManager.checkSignatures(
+    1,
     ethUtils.bufferToHex(ethUtils.keccak256(voteData)),
     stateRoot,
     sigs,
@@ -74,7 +76,8 @@ export function assertBigNumbergt(num1, num2) {
   // num1.should.be.bignumber.greaterThan(num2)
 }
 
-export const toChecksumAddress = address => web3.utils.toChecksumAddress(address)
+export const toChecksumAddress = address =>
+  web3.utils.toChecksumAddress(address)
 
 export function buildSubmitHeaderBlockPaylod(
   proposer,
@@ -152,7 +155,9 @@ export async function depositOnRoot(
     )
   }
   const logs = logDecoder.decodeLogs(result.receipt.rawLogs)
-  const NewDepositBlockEvent = logs.find(log => log.event === 'NewDepositBlock')
+  const NewDepositBlockEvent = logs.find(
+    log => log.event === 'NewDepositBlock'
+  )
   return NewDepositBlockEvent.args.depositBlockId
 }
 

--- a/test/root/RootChain.test.js
+++ b/test/root/RootChain.test.js
@@ -41,6 +41,7 @@ contract('RootChain', async function(accounts) {
     stakeToken = await DummyERC20.new('Stake Token', 'STAKE')
     await stakeManager.setToken(stakeToken.address)
     await stakeManager.changeRootChain(rootChain.address)
+    await stakeManager.updateCheckPointBlockInterval(1)
 
     let amount = web3.utils.toWei('1000')
     for (let i = 0; i < 4; i++) {

--- a/test/staking/DelegationManager.test.js
+++ b/test/staking/DelegationManager.test.js
@@ -30,6 +30,7 @@ contract('DelegationManager', async function(accounts) {
     await stakeManager.setToken(stakeToken.address)
     await delegationManager.setToken(stakeToken.address)
     await stakeManager.updateValidatorThreshold(3)
+    await stakeManager.updateCheckPointBlockInterval(1)
     await stakeManager.changeRootChain(wallets[0].getAddressString())
     // transfer tokens to other accounts
     await stakeToken.mint(

--- a/test/staking/SlashingManager.test.js
+++ b/test/staking/SlashingManager.test.js
@@ -26,6 +26,8 @@ contract('SlashingManager', async function(accounts) {
     await stakeManager.setToken(stakeToken.address)
 
     await stakeManager.updateValidatorThreshold(3)
+    await stakeManager.updateCheckPointBlockInterval(1)
+
     await stakeManager.changeRootChain(wallets[0].getAddressString())
     SlashingManager = contracts.SlashingManager
 

--- a/test/staking/StakeDelegationManager.test.js
+++ b/test/staking/StakeDelegationManager.test.js
@@ -37,6 +37,7 @@ contract('StakeManager<->DelegationManager', async function(accounts) {
     await stakeManager.changeRootChain(wallets[0].getAddressString())
     await delegationManager.setToken(stakeToken.address)
     await stakeManager.updateValidatorThreshold(3)
+    await stakeManager.updateCheckPointBlockInterval(1)
 
     await stakeManager.updateDynastyValue(2)
     // transfer tokens to other accounts

--- a/test/staking/StakeManager.test.js
+++ b/test/staking/StakeManager.test.js
@@ -22,7 +22,7 @@ import { generateFirstWallets, mnemonics } from '../helpers/wallets.js'
 
 chai.use(chaiAsPromised).should()
 
-contract('StakeManager', async function (accounts) {
+contract('StakeManager', async function(accounts) {
   let stakeToken
   let stakeManager
   let wallets
@@ -30,8 +30,8 @@ contract('StakeManager', async function (accounts) {
   let owner = accounts[0]
 
   // staking
-  describe('Stake', async function () {
-    before(async function () {
+  describe('Stake', async function() {
+    before(async function() {
       wallets = generateFirstWallets(mnemonics, 10)
       stakeToken = await DummyERC20.new('Stake Token', 'STAKE')
       stakeManager = await StakeManager.new(
@@ -39,7 +39,7 @@ contract('StakeManager', async function (accounts) {
         wallets[1].getAddressString()
       ) // dummy registry address
       await stakeManager.setToken(stakeToken.address)
-
+      await stakeManager.updateCheckPointBlockInterval(1)
       // transfer tokens to other accounts
       await stakeToken.mint(
         wallets[0].getAddressString(),
@@ -83,7 +83,7 @@ contract('StakeManager', async function (accounts) {
       )
     })
 
-    it('should set the validator threshold to 5, dynasty value to 2 epochs', async function () {
+    it('should set the validator threshold to 5, dynasty value to 2 epochs', async function() {
       const thresholdReceipt = await stakeManager.updateValidatorThreshold(5, {
         from: owner
       })
@@ -107,12 +107,12 @@ contract('StakeManager', async function (accounts) {
       // logs1[0].args.oldDynasty.should.be.bignumber.equal(250)
     })
 
-    it('should set token address and owner properly', async function () {
+    it('should set token address and owner properly', async function() {
       await stakeManager.token().should.eventually.equal(stakeToken.address)
       await stakeManager.owner().should.eventually.equal(owner)
     })
 
-    it('should stake via wallets[1]', async function () {
+    it('should stake via wallets[1]', async function() {
       const user = wallets[1].getAddressString()
       const amount = web3.utils.toWei('200')
 
@@ -139,7 +139,7 @@ contract('StakeManager', async function (accounts) {
       // logs[2].args.amount.should.be.bignumber.equal(amount)
     })
 
-    it('should stake via wallets[2]', async function () {
+    it('should stake via wallets[2]', async function() {
       const user = wallets[2].getAddressString()
       const amount = web3.utils.toWei('250')
 
@@ -174,7 +174,7 @@ contract('StakeManager', async function (accounts) {
       // stakedFor.should.be.bignumber.equal(amount)
     })
 
-    it('should stake via wallets[3]', async function () {
+    it('should stake via wallets[3]', async function() {
       const user = wallets[3].getAddressString()
       const amount = web3.utils.toWei('300')
 
@@ -196,7 +196,7 @@ contract('StakeManager', async function (accounts) {
       assert.isTrue(value)
     })
 
-    it('Duplicate: should stake via wallets[3] fail', async function () {
+    it('Duplicate: should stake via wallets[3] fail', async function() {
       const user = wallets[3].getAddressString()
       const amount = web3.utils.toWei('30')
 
@@ -222,7 +222,7 @@ contract('StakeManager', async function (accounts) {
       // stakedFor.should.be.bignumber.equal(web3.utils.toWei(300))
     })
 
-    it('should stake via wallets[4-5]', async function () {
+    it('should stake via wallets[4-5]', async function() {
       let user = wallets[4].getAddressString()
       let amount = web3.utils.toWei('750')
 
@@ -259,7 +259,7 @@ contract('StakeManager', async function (accounts) {
       stakerDetails[3].toLowerCase().should.equal(user)
     })
 
-    it('should update and verify signer/pubkey', async function () {
+    it('should update and verify signer/pubkey', async function() {
       let user = wallets[5].getAddressString()
       let w = [wallets[1], wallets[2], wallets[3], wallets[4]]
       await checkPoint(w, wallets[1], stakeManager)
@@ -290,7 +290,7 @@ contract('StakeManager', async function (accounts) {
       stakerDetails[3].toLowerCase().should.equal(user)
     })
 
-    it('should try to stake after validator threshold', async function () {
+    it('should try to stake after validator threshold', async function() {
       const user = wallets[6].getAddressString()
       const amount = web3.utils.toWei('100')
 
@@ -316,14 +316,14 @@ contract('StakeManager', async function (accounts) {
       assertBigNumberEquality(stakedFor, '0')
     })
 
-    it('should verify running total stake to be correct', async function () {
+    it('should verify running total stake to be correct', async function() {
       const stake = await stakeManager.currentValidatorSetTotalStake()
       // stake.should.be.bignumber.equal(web3.utils.toWei(2240))
       assertBigNumberEquality(stake, web3.utils.toWei('2240'))
       const validators = await stakeManager.getCurrentValidatorSet()
       validators.should.have.lengthOf(5)
     })
-    it('should unstake via wallets[2]', async function () {
+    it('should unstake via wallets[2]', async function() {
       const user = wallets[2].getAddressString()
       const amount = web3.utils.toWei('250')
 
@@ -342,7 +342,7 @@ contract('StakeManager', async function (accounts) {
       assertBigNumberEquality(logs[0].args.validatorId, validatorId)
     })
 
-    it('should unstake via wallets[3] after 2 epoch', async function () {
+    it('should unstake via wallets[3] after 2 epoch', async function() {
       const user = wallets[3].getAddressString()
       const amount = web3.utils.toWei('300')
       let w = [wallets[1], wallets[3], wallets[4], wallets[5]]
@@ -366,7 +366,7 @@ contract('StakeManager', async function (accounts) {
       // logs[0].args.validatorId.should.be.bignumber.equal(validatorId)
       assertBigNumberEquality(logs[0].args.validatorId, validatorId)
     })
-    it('should set the validator threshold to 6, dynasty value to 2 epochs', async function () {
+    it('should set the validator threshold to 6, dynasty value to 2 epochs', async function() {
       const thresholdReceipt = await stakeManager.updateValidatorThreshold(6, {
         from: owner
       })
@@ -380,7 +380,7 @@ contract('StakeManager', async function (accounts) {
       assertBigNumberEquality(newThreshold, '6')
     })
 
-    it('should stake via wallets[6]', async function () {
+    it('should stake via wallets[6]', async function() {
       const user = wallets[6].getAddressString()
       const amount = web3.utils.toWei('400')
       let w = [wallets[1], wallets[5], wallets[4]]
@@ -405,7 +405,7 @@ contract('StakeManager', async function (accounts) {
       })
     })
 
-    it('should stake via wallets[7]', async function () {
+    it('should stake via wallets[7]', async function() {
       let user = wallets[7].getAddressString()
       let amount = web3.utils.toWei('450')
 
@@ -432,7 +432,7 @@ contract('StakeManager', async function (accounts) {
       })
     })
 
-    it('should verify unstaked amount', async function () {
+    it('should verify unstaked amount', async function() {
       const ValidatorId2 = await stakeManager.getValidatorId(
         wallets[2].getAddressString()
       )
@@ -459,7 +459,7 @@ contract('StakeManager', async function (accounts) {
       assertBigNumberEquality(balance, web3.utils.toWei('850'))
     })
 
-    it('should verify running total stake to be correct', async function () {
+    it('should verify running total stake to be correct', async function() {
       const amount = web3.utils.toWei('3390')
       //   const currentEpoch = await stakeManager.currentEpoch()
       const stake = await stakeManager.currentValidatorSetTotalStake()
@@ -481,7 +481,7 @@ contract('StakeManager', async function (accounts) {
       // expect(validators).to.equal(users)
     })
 
-    it('should create sigs properly', async function () {
+    it('should create sigs properly', async function() {
       // dummy vote data
       let w = [wallets[0], wallets[4], wallets[6], wallets[7], wallets[5]]
       await checkPoint(w, wallets[1], stakeManager, {
@@ -491,15 +491,15 @@ contract('StakeManager', async function (accounts) {
   })
 })
 
-contract('StakeManager:rewards distribution', async function (accounts) {
+contract('StakeManager:rewards distribution', async function(accounts) {
   let stakeToken
   let stakeManager
   let wallets
   let accountState = {}
   const rewardsAmount = 5
 
-  describe('staking rewards', async function () {
-    before(async function () {
+  describe('staking rewards', async function() {
+    before(async function() {
       wallets = generateFirstWallets(mnemonics, 2)
       stakeToken = await DummyERC20.new('Stake Token', 'STAKE')
       stakeManager = await StakeManager.new(
@@ -507,7 +507,7 @@ contract('StakeManager:rewards distribution', async function (accounts) {
         wallets[0].getAddressString()
       ) // dummy registry address
       await stakeManager.setToken(stakeToken.address)
-
+      await stakeManager.updateCheckPointBlockInterval(1)
       let amount = web3.utils.toWei('1000')
       for (let i = 0; i < 2; i++) {
         await stakeToken.mint(wallets[i].getAddressString(), amount)
@@ -521,7 +521,7 @@ contract('StakeManager:rewards distribution', async function (accounts) {
       }
     })
 
-    it('should get rewards for validator [1, 2]', async function () {
+    it('should get rewards for validator [1, 2]', async function() {
       const validators = [1, 2]
       let tree = await rewradsTree(validators, accountState)
       const { vote, sigs } = buildSubmitHeaderBlockPaylod(
@@ -568,7 +568,7 @@ contract('StakeManager:rewards distribution', async function (accounts) {
   })
 })
 
-contract('StakeManager:validator contract rewards distribution', async function (
+contract('StakeManager:validator contract rewards distribution', async function(
   accounts
 ) {
   let stakeToken
@@ -577,8 +577,8 @@ contract('StakeManager:validator contract rewards distribution', async function 
   let accountState = {}
   const rewardsAmount = 5
 
-  describe('staking rewards', async function () {
-    before(async function () {
+  describe('staking rewards', async function() {
+    before(async function() {
       wallets = generateFirstWallets(mnemonics, 2)
       stakeToken = await DummyERC20.new('Stake Token', 'STAKE')
       stakeManager = await StakeManager.new(
@@ -586,6 +586,7 @@ contract('StakeManager:validator contract rewards distribution', async function 
         wallets[0].getAddressString()
       ) // dummy registry address
       await stakeManager.setToken(stakeToken.address)
+      await stakeManager.updateCheckPointBlockInterval(1)
 
       let amount = web3.utils.toWei('1000')
       for (let i = 0; i < 2; i++) {
@@ -600,7 +601,7 @@ contract('StakeManager:validator contract rewards distribution', async function 
       }
     })
 
-    it('should get rewards for validator 1 with ValidatorContract/delegation on', async function () {
+    it('should get rewards for validator 1 with ValidatorContract/delegation on', async function() {
       const validators = [1, 2]
       let tree = await rewradsTree(validators, accountState)
       const { vote, sigs } = buildSubmitHeaderBlockPaylod(
@@ -657,15 +658,15 @@ contract('StakeManager:validator contract rewards distribution', async function 
   })
 })
 
-contract('StakeManager:validator replacement', async function (accounts) {
+contract('StakeManager:validator replacement', async function(accounts) {
   let stakeToken
   let stakeManager
   let wallets
   let accountState = {}
   const rewardsAmount = 5
 
-  describe('validator replacement', async function () {
-    before(async function () {
+  describe('validator replacement', async function() {
+    before(async function() {
       wallets = generateFirstWallets(mnemonics, 10)
       stakeToken = await DummyERC20.new('Stake Token', 'STAKE')
       stakeManager = await StakeManager.new(
@@ -674,6 +675,7 @@ contract('StakeManager:validator replacement', async function (accounts) {
       ) // dummy registry address
       await stakeManager.setToken(stakeToken.address)
       await stakeManager.updateDynastyValue(8)
+      await stakeManager.updateCheckPointBlockInterval(1)
 
       let amount = web3.utils.toWei('1000')
       for (let i = 0; i < 2; i++) {
@@ -688,7 +690,7 @@ contract('StakeManager:validator replacement', async function (accounts) {
       }
     })
 
-    it('should try auction start in non-auction period and fail', async function () {
+    it('should try auction start in non-auction period and fail', async function() {
       const amount = web3.utils.toWei('1200')
       await stakeToken.mint(wallets[3].getAddressString(), amount)
       await stakeToken.approve(stakeManager.address, amount, {
@@ -705,7 +707,7 @@ contract('StakeManager:validator replacement', async function (accounts) {
       }
     })
 
-    it('should start Auction and bid multiple times', async function () {
+    it('should start Auction and bid multiple times', async function() {
       let amount = web3.utils.toWei('1200')
       const { vote, sigs } = buildSubmitHeaderBlockPaylod(
         accounts[0],
@@ -779,7 +781,7 @@ contract('StakeManager:validator replacement', async function (accounts) {
       )
     })
 
-    it('should start auction where validator is last bidder', async function () {
+    it('should start auction where validator is last bidder', async function() {
       const amount = web3.utils.toWei('1250')
       let validator = await stakeManager.validators(2)
       assert(
@@ -800,7 +802,7 @@ contract('StakeManager:validator replacement', async function (accounts) {
       assert(auctionData.user.toLowerCase() === validator.signer.toLowerCase())
     })
 
-    it('should try to unstake in auction interval and fail', async function () {
+    it('should try to unstake in auction interval and fail', async function() {
       try {
         await stakeManager.unstake(1, {
           from: wallets[0].getAddressString()
@@ -812,7 +814,7 @@ contract('StakeManager:validator replacement', async function (accounts) {
       }
     })
 
-    it('should try auction start after auctionPeriod period and fail', async function () {
+    it('should try auction start after auctionPeriod period and fail', async function() {
       const { vote, sigs } = buildSubmitHeaderBlockPaylod(
         accounts[0],
         0,
@@ -864,7 +866,7 @@ contract('StakeManager:validator replacement', async function (accounts) {
       }
     })
 
-    it('should confrim auction and secure the place', async function () {
+    it('should confrim auction and secure the place', async function() {
       const result = await stakeManager.confirmAuctionBid(
         1,
         wallets[4].getAddressString(),
@@ -883,7 +885,7 @@ contract('StakeManager:validator replacement', async function (accounts) {
       assert.ok(await stakeManager.isValidator(logs[3].args.newValidatorId))
     })
 
-    it('should confrim auction and secure the place for validator itself', async function () {
+    it('should confrim auction and secure the place for validator itself', async function() {
       let validator = await stakeManager.validators(2)
       let stake = validator.amount
       let balanceBefore = await stakeToken.balanceOf(validator.signer)

--- a/test/staking/StakeManager.test.js
+++ b/test/staking/StakeManager.test.js
@@ -22,7 +22,7 @@ import { generateFirstWallets, mnemonics } from '../helpers/wallets.js'
 
 chai.use(chaiAsPromised).should()
 
-contract('StakeManager', async function(accounts) {
+contract('StakeManager', async functionaccounts) {
   let stakeToken
   let stakeManager
   let wallets
@@ -30,8 +30,8 @@ contract('StakeManager', async function(accounts) {
   let owner = accounts[0]
 
   // staking
-  describe('Stake', async function() {
-    before(async function() {
+  describe('Stake', async function) {
+    before(async function) {
       wallets = generateFirstWallets(mnemonics, 10)
       stakeToken = await DummyERC20.new('Stake Token', 'STAKE')
       stakeManager = await StakeManager.new(
@@ -83,7 +83,7 @@ contract('StakeManager', async function(accounts) {
       )
     })
 
-    it('should set the validator threshold to 5, dynasty value to 2 epochs', async function() {
+    it('should set the validator threshold to 5, dynasty value to 2 epochs', async function) {
       const thresholdReceipt = await stakeManager.updateValidatorThreshold(5, {
         from: owner
       })
@@ -107,12 +107,12 @@ contract('StakeManager', async function(accounts) {
       // logs1[0].args.oldDynasty.should.be.bignumber.equal(250)
     })
 
-    it('should set token address and owner properly', async function() {
+    it('should set token address and owner properly', async function) {
       await stakeManager.token().should.eventually.equal(stakeToken.address)
       await stakeManager.owner().should.eventually.equal(owner)
     })
 
-    it('should stake via wallets[1]', async function() {
+    it('should stake via wallets[1]', async function) {
       const user = wallets[1].getAddressString()
       const amount = web3.utils.toWei('200')
 
@@ -139,7 +139,7 @@ contract('StakeManager', async function(accounts) {
       // logs[2].args.amount.should.be.bignumber.equal(amount)
     })
 
-    it('should stake via wallets[2]', async function() {
+    it('should stake via wallets[2]', async function) {
       const user = wallets[2].getAddressString()
       const amount = web3.utils.toWei('250')
 
@@ -174,7 +174,7 @@ contract('StakeManager', async function(accounts) {
       // stakedFor.should.be.bignumber.equal(amount)
     })
 
-    it('should stake via wallets[3]', async function() {
+    it('should stake via wallets[3]', async function) {
       const user = wallets[3].getAddressString()
       const amount = web3.utils.toWei('300')
 
@@ -196,7 +196,7 @@ contract('StakeManager', async function(accounts) {
       assert.isTrue(value)
     })
 
-    it('Duplicate: should stake via wallets[3] fail', async function() {
+    it('Duplicate: should stake via wallets[3] fail', async function) {
       const user = wallets[3].getAddressString()
       const amount = web3.utils.toWei('30')
 
@@ -222,7 +222,7 @@ contract('StakeManager', async function(accounts) {
       // stakedFor.should.be.bignumber.equal(web3.utils.toWei(300))
     })
 
-    it('should stake via wallets[4-5]', async function() {
+    it('should stake via wallets[4-5]', async function) {
       let user = wallets[4].getAddressString()
       let amount = web3.utils.toWei('750')
 
@@ -259,7 +259,7 @@ contract('StakeManager', async function(accounts) {
       stakerDetails[3].toLowerCase().should.equal(user)
     })
 
-    it('should update and verify signer/pubkey', async function() {
+    it('should update and verify signer/pubkey', async function) {
       let user = wallets[5].getAddressString()
       let w = [wallets[1], wallets[2], wallets[3], wallets[4]]
       await checkPoint(w, wallets[1], stakeManager)
@@ -290,7 +290,7 @@ contract('StakeManager', async function(accounts) {
       stakerDetails[3].toLowerCase().should.equal(user)
     })
 
-    it('should try to stake after validator threshold', async function() {
+    it('should try to stake after validator threshold', async function) {
       const user = wallets[6].getAddressString()
       const amount = web3.utils.toWei('100')
 
@@ -316,14 +316,14 @@ contract('StakeManager', async function(accounts) {
       assertBigNumberEquality(stakedFor, '0')
     })
 
-    it('should verify running total stake to be correct', async function() {
+    it('should verify running total stake to be correct', async function) {
       const stake = await stakeManager.currentValidatorSetTotalStake()
       // stake.should.be.bignumber.equal(web3.utils.toWei(2240))
       assertBigNumberEquality(stake, web3.utils.toWei('2240'))
       const validators = await stakeManager.getCurrentValidatorSet()
       validators.should.have.lengthOf(5)
     })
-    it('should unstake via wallets[2]', async function() {
+    it('should unstake via wallets[2]', async function) {
       const user = wallets[2].getAddressString()
       const amount = web3.utils.toWei('250')
 
@@ -342,7 +342,7 @@ contract('StakeManager', async function(accounts) {
       assertBigNumberEquality(logs[0].args.validatorId, validatorId)
     })
 
-    it('should unstake via wallets[3] after 2 epoch', async function() {
+    it('should unstake via wallets[3] after 2 epoch', async function) {
       const user = wallets[3].getAddressString()
       const amount = web3.utils.toWei('300')
       let w = [wallets[1], wallets[3], wallets[4], wallets[5]]
@@ -366,7 +366,7 @@ contract('StakeManager', async function(accounts) {
       // logs[0].args.validatorId.should.be.bignumber.equal(validatorId)
       assertBigNumberEquality(logs[0].args.validatorId, validatorId)
     })
-    it('should set the validator threshold to 6, dynasty value to 2 epochs', async function() {
+    it('should set the validator threshold to 6, dynasty value to 2 epochs', async function) {
       const thresholdReceipt = await stakeManager.updateValidatorThreshold(6, {
         from: owner
       })
@@ -380,7 +380,7 @@ contract('StakeManager', async function(accounts) {
       assertBigNumberEquality(newThreshold, '6')
     })
 
-    it('should stake via wallets[6]', async function() {
+    it('should stake via wallets[6]', async function) {
       const user = wallets[6].getAddressString()
       const amount = web3.utils.toWei('400')
       let w = [wallets[1], wallets[5], wallets[4]]
@@ -405,7 +405,7 @@ contract('StakeManager', async function(accounts) {
       })
     })
 
-    it('should stake via wallets[7]', async function() {
+    it('should stake via wallets[7]', async function) {
       let user = wallets[7].getAddressString()
       let amount = web3.utils.toWei('450')
 
@@ -432,7 +432,7 @@ contract('StakeManager', async function(accounts) {
       })
     })
 
-    it('should verify unstaked amount', async function() {
+    it('should verify unstaked amount', async function) {
       const ValidatorId2 = await stakeManager.getValidatorId(
         wallets[2].getAddressString()
       )
@@ -459,7 +459,7 @@ contract('StakeManager', async function(accounts) {
       assertBigNumberEquality(balance, web3.utils.toWei('850'))
     })
 
-    it('should verify running total stake to be correct', async function() {
+    it('should verify running total stake to be correct', async function) {
       const amount = web3.utils.toWei('3390')
       //   const currentEpoch = await stakeManager.currentEpoch()
       const stake = await stakeManager.currentValidatorSetTotalStake()
@@ -481,7 +481,7 @@ contract('StakeManager', async function(accounts) {
       // expect(validators).to.equal(users)
     })
 
-    it('should create sigs properly', async function() {
+    it('should create sigs properly', async function) {
       // dummy vote data
       let w = [wallets[0], wallets[4], wallets[6], wallets[7], wallets[5]]
       await checkPoint(w, wallets[1], stakeManager, {
@@ -491,15 +491,15 @@ contract('StakeManager', async function(accounts) {
   })
 })
 
-contract('StakeManager:rewards distribution', async function(accounts) {
+contract('StakeManager:rewards distribution', async functionaccounts) {
   let stakeToken
   let stakeManager
   let wallets
   let accountState = {}
   const rewardsAmount = 5
 
-  describe('staking rewards', async function() {
-    before(async function() {
+  describe('staking rewards', async function) {
+    before(async function) {
       wallets = generateFirstWallets(mnemonics, 2)
       stakeToken = await DummyERC20.new('Stake Token', 'STAKE')
       stakeManager = await StakeManager.new(
@@ -521,7 +521,7 @@ contract('StakeManager:rewards distribution', async function(accounts) {
       }
     })
 
-    it('should get rewards for validator [1, 2]', async function() {
+    it('should get rewards for validator [1, 2]', async function) {
       const validators = [1, 2]
       let tree = await rewradsTree(validators, accountState)
       const { vote, sigs } = buildSubmitHeaderBlockPaylod(
@@ -535,6 +535,7 @@ contract('StakeManager:rewards distribution', async function(accounts) {
 
       // 2/3 majority vote
       await stakeManager.checkSignatures(
+        1,
         utils.bufferToHex(utils.keccak256(vote)),
         utils.bufferToHex(tree.getRoot()),
         sigs
@@ -567,7 +568,7 @@ contract('StakeManager:rewards distribution', async function(accounts) {
   })
 })
 
-contract('StakeManager:validator contract rewards distribution', async function(
+contract('StakeManager:validator contract rewards distribution', async function
   accounts
 ) {
   let stakeToken
@@ -576,8 +577,8 @@ contract('StakeManager:validator contract rewards distribution', async function(
   let accountState = {}
   const rewardsAmount = 5
 
-  describe('staking rewards', async function() {
-    before(async function() {
+  describe('staking rewards', async function) {
+    before(async function) {
       wallets = generateFirstWallets(mnemonics, 2)
       stakeToken = await DummyERC20.new('Stake Token', 'STAKE')
       stakeManager = await StakeManager.new(
@@ -599,7 +600,7 @@ contract('StakeManager:validator contract rewards distribution', async function(
       }
     })
 
-    it('should get rewards for validator 1 with ValidatorContract/delegation on', async function() {
+    it('should get rewards for validator 1 with ValidatorContract/delegation on', async function) {
       const validators = [1, 2]
       let tree = await rewradsTree(validators, accountState)
       const { vote, sigs } = buildSubmitHeaderBlockPaylod(
@@ -617,6 +618,7 @@ contract('StakeManager:validator contract rewards distribution', async function(
 
       // 2/3 majority vote
       await stakeManager.checkSignatures(
+        1,
         utils.bufferToHex(utils.keccak256(vote)),
         utils.bufferToHex(tree.getRoot()),
         sigs
@@ -655,15 +657,15 @@ contract('StakeManager:validator contract rewards distribution', async function(
   })
 })
 
-contract('StakeManager:validator replacement', async function(accounts) {
+contract('StakeManager:validator replacement', async functionaccounts) {
   let stakeToken
   let stakeManager
   let wallets
   let accountState = {}
   const rewardsAmount = 5
 
-  describe('validator replacement', async function() {
-    before(async function() {
+  describe('validator replacement', async function) {
+    before(async function) {
       wallets = generateFirstWallets(mnemonics, 10)
       stakeToken = await DummyERC20.new('Stake Token', 'STAKE')
       stakeManager = await StakeManager.new(
@@ -686,7 +688,7 @@ contract('StakeManager:validator replacement', async function(accounts) {
       }
     })
 
-    it('should try auction start in non-auction period and fail', async function() {
+    it('should try auction start in non-auction period and fail', async function) {
       const amount = web3.utils.toWei('1200')
       await stakeToken.mint(wallets[3].getAddressString(), amount)
       await stakeToken.approve(stakeManager.address, amount, {
@@ -703,7 +705,7 @@ contract('StakeManager:validator replacement', async function(accounts) {
       }
     })
 
-    it('should start Auction and bid multiple times', async function() {
+    it('should start Auction and bid multiple times', async function) {
       let amount = web3.utils.toWei('1200')
       const { vote, sigs } = buildSubmitHeaderBlockPaylod(
         accounts[0],
@@ -722,6 +724,7 @@ contract('StakeManager:validator replacement', async function(accounts) {
       for (let i = currentEpoch; i <= auction.startEpoch; i++) {
         // 2/3 majority vote
         await stakeManager.checkSignatures(
+          1,
           utils.bufferToHex(utils.keccak256(vote)),
           utils.bufferToHex(''),
           sigs
@@ -741,7 +744,7 @@ contract('StakeManager:validator replacement', async function(accounts) {
       assertBigNumberEquality(auctionData.amount, amount)
       assert(
         auctionData.user.toLowerCase ===
-          wallets[3].getAddressString().toLowerCase
+        wallets[3].getAddressString().toLowerCase
       )
       amount = web3.utils.toWei('1250')
       // outbid wallet[3] from wallet[4]
@@ -772,11 +775,11 @@ contract('StakeManager:validator replacement', async function(accounts) {
       assertBigNumberEquality(auctionData.amount, amount)
       assert(
         auctionData.user.toLowerCase() ===
-          wallets[4].getAddressString().toLowerCase()
+        wallets[4].getAddressString().toLowerCase()
       )
     })
 
-    it('should start auction where validator is last bidder', async function() {
+    it('should start auction where validator is last bidder', async function) {
       const amount = web3.utils.toWei('1250')
       let validator = await stakeManager.validators(2)
       assert(
@@ -797,7 +800,7 @@ contract('StakeManager:validator replacement', async function(accounts) {
       assert(auctionData.user.toLowerCase() === validator.signer.toLowerCase())
     })
 
-    it('should try to unstake in auction interval and fail', async function() {
+    it('should try to unstake in auction interval and fail', async function) {
       try {
         await stakeManager.unstake(1, {
           from: wallets[0].getAddressString()
@@ -809,7 +812,7 @@ contract('StakeManager:validator replacement', async function(accounts) {
       }
     })
 
-    it('should try auction start after auctionPeriod period and fail', async function() {
+    it('should try auction start after auctionPeriod period and fail', async function) {
       const { vote, sigs } = buildSubmitHeaderBlockPaylod(
         accounts[0],
         0,
@@ -834,6 +837,7 @@ contract('StakeManager:validator replacement', async function(accounts) {
       ) {
         // 2/3 majority vote
         await stakeManager.checkSignatures(
+          1,
           utils.bufferToHex(utils.keccak256(vote)),
           utils.bufferToHex(''),
           sigs
@@ -860,7 +864,7 @@ contract('StakeManager:validator replacement', async function(accounts) {
       }
     })
 
-    it('should confrim auction and secure the place', async function() {
+    it('should confrim auction and secure the place', async function) {
       const result = await stakeManager.confirmAuctionBid(
         1,
         wallets[4].getAddressString(),
@@ -879,7 +883,7 @@ contract('StakeManager:validator replacement', async function(accounts) {
       assert.ok(await stakeManager.isValidator(logs[3].args.newValidatorId))
     })
 
-    it('should confrim auction and secure the place for validator itself', async function() {
+    it('should confrim auction and secure the place for validator itself', async function) {
       let validator = await stakeManager.validators(2)
       let stake = validator.amount
       let balanceBefore = await stakeToken.balanceOf(validator.signer)

--- a/test/staking/StakeManager.test.js
+++ b/test/staking/StakeManager.test.js
@@ -22,7 +22,7 @@ import { generateFirstWallets, mnemonics } from '../helpers/wallets.js'
 
 chai.use(chaiAsPromised).should()
 
-contract('StakeManager', async functionaccounts) {
+contract('StakeManager', async function (accounts) {
   let stakeToken
   let stakeManager
   let wallets
@@ -30,8 +30,8 @@ contract('StakeManager', async functionaccounts) {
   let owner = accounts[0]
 
   // staking
-  describe('Stake', async function) {
-    before(async function) {
+  describe('Stake', async function () {
+    before(async function () {
       wallets = generateFirstWallets(mnemonics, 10)
       stakeToken = await DummyERC20.new('Stake Token', 'STAKE')
       stakeManager = await StakeManager.new(
@@ -83,7 +83,7 @@ contract('StakeManager', async functionaccounts) {
       )
     })
 
-    it('should set the validator threshold to 5, dynasty value to 2 epochs', async function) {
+    it('should set the validator threshold to 5, dynasty value to 2 epochs', async function () {
       const thresholdReceipt = await stakeManager.updateValidatorThreshold(5, {
         from: owner
       })
@@ -107,12 +107,12 @@ contract('StakeManager', async functionaccounts) {
       // logs1[0].args.oldDynasty.should.be.bignumber.equal(250)
     })
 
-    it('should set token address and owner properly', async function) {
+    it('should set token address and owner properly', async function () {
       await stakeManager.token().should.eventually.equal(stakeToken.address)
       await stakeManager.owner().should.eventually.equal(owner)
     })
 
-    it('should stake via wallets[1]', async function) {
+    it('should stake via wallets[1]', async function () {
       const user = wallets[1].getAddressString()
       const amount = web3.utils.toWei('200')
 
@@ -139,7 +139,7 @@ contract('StakeManager', async functionaccounts) {
       // logs[2].args.amount.should.be.bignumber.equal(amount)
     })
 
-    it('should stake via wallets[2]', async function) {
+    it('should stake via wallets[2]', async function () {
       const user = wallets[2].getAddressString()
       const amount = web3.utils.toWei('250')
 
@@ -174,7 +174,7 @@ contract('StakeManager', async functionaccounts) {
       // stakedFor.should.be.bignumber.equal(amount)
     })
 
-    it('should stake via wallets[3]', async function) {
+    it('should stake via wallets[3]', async function () {
       const user = wallets[3].getAddressString()
       const amount = web3.utils.toWei('300')
 
@@ -196,7 +196,7 @@ contract('StakeManager', async functionaccounts) {
       assert.isTrue(value)
     })
 
-    it('Duplicate: should stake via wallets[3] fail', async function) {
+    it('Duplicate: should stake via wallets[3] fail', async function () {
       const user = wallets[3].getAddressString()
       const amount = web3.utils.toWei('30')
 
@@ -222,7 +222,7 @@ contract('StakeManager', async functionaccounts) {
       // stakedFor.should.be.bignumber.equal(web3.utils.toWei(300))
     })
 
-    it('should stake via wallets[4-5]', async function) {
+    it('should stake via wallets[4-5]', async function () {
       let user = wallets[4].getAddressString()
       let amount = web3.utils.toWei('750')
 
@@ -259,7 +259,7 @@ contract('StakeManager', async functionaccounts) {
       stakerDetails[3].toLowerCase().should.equal(user)
     })
 
-    it('should update and verify signer/pubkey', async function) {
+    it('should update and verify signer/pubkey', async function () {
       let user = wallets[5].getAddressString()
       let w = [wallets[1], wallets[2], wallets[3], wallets[4]]
       await checkPoint(w, wallets[1], stakeManager)
@@ -290,7 +290,7 @@ contract('StakeManager', async functionaccounts) {
       stakerDetails[3].toLowerCase().should.equal(user)
     })
 
-    it('should try to stake after validator threshold', async function) {
+    it('should try to stake after validator threshold', async function () {
       const user = wallets[6].getAddressString()
       const amount = web3.utils.toWei('100')
 
@@ -316,14 +316,14 @@ contract('StakeManager', async functionaccounts) {
       assertBigNumberEquality(stakedFor, '0')
     })
 
-    it('should verify running total stake to be correct', async function) {
+    it('should verify running total stake to be correct', async function () {
       const stake = await stakeManager.currentValidatorSetTotalStake()
       // stake.should.be.bignumber.equal(web3.utils.toWei(2240))
       assertBigNumberEquality(stake, web3.utils.toWei('2240'))
       const validators = await stakeManager.getCurrentValidatorSet()
       validators.should.have.lengthOf(5)
     })
-    it('should unstake via wallets[2]', async function) {
+    it('should unstake via wallets[2]', async function () {
       const user = wallets[2].getAddressString()
       const amount = web3.utils.toWei('250')
 
@@ -342,7 +342,7 @@ contract('StakeManager', async functionaccounts) {
       assertBigNumberEquality(logs[0].args.validatorId, validatorId)
     })
 
-    it('should unstake via wallets[3] after 2 epoch', async function) {
+    it('should unstake via wallets[3] after 2 epoch', async function () {
       const user = wallets[3].getAddressString()
       const amount = web3.utils.toWei('300')
       let w = [wallets[1], wallets[3], wallets[4], wallets[5]]
@@ -366,7 +366,7 @@ contract('StakeManager', async functionaccounts) {
       // logs[0].args.validatorId.should.be.bignumber.equal(validatorId)
       assertBigNumberEquality(logs[0].args.validatorId, validatorId)
     })
-    it('should set the validator threshold to 6, dynasty value to 2 epochs', async function) {
+    it('should set the validator threshold to 6, dynasty value to 2 epochs', async function () {
       const thresholdReceipt = await stakeManager.updateValidatorThreshold(6, {
         from: owner
       })
@@ -380,7 +380,7 @@ contract('StakeManager', async functionaccounts) {
       assertBigNumberEquality(newThreshold, '6')
     })
 
-    it('should stake via wallets[6]', async function) {
+    it('should stake via wallets[6]', async function () {
       const user = wallets[6].getAddressString()
       const amount = web3.utils.toWei('400')
       let w = [wallets[1], wallets[5], wallets[4]]
@@ -405,7 +405,7 @@ contract('StakeManager', async functionaccounts) {
       })
     })
 
-    it('should stake via wallets[7]', async function) {
+    it('should stake via wallets[7]', async function () {
       let user = wallets[7].getAddressString()
       let amount = web3.utils.toWei('450')
 
@@ -432,7 +432,7 @@ contract('StakeManager', async functionaccounts) {
       })
     })
 
-    it('should verify unstaked amount', async function) {
+    it('should verify unstaked amount', async function () {
       const ValidatorId2 = await stakeManager.getValidatorId(
         wallets[2].getAddressString()
       )
@@ -459,7 +459,7 @@ contract('StakeManager', async functionaccounts) {
       assertBigNumberEquality(balance, web3.utils.toWei('850'))
     })
 
-    it('should verify running total stake to be correct', async function) {
+    it('should verify running total stake to be correct', async function () {
       const amount = web3.utils.toWei('3390')
       //   const currentEpoch = await stakeManager.currentEpoch()
       const stake = await stakeManager.currentValidatorSetTotalStake()
@@ -481,7 +481,7 @@ contract('StakeManager', async functionaccounts) {
       // expect(validators).to.equal(users)
     })
 
-    it('should create sigs properly', async function) {
+    it('should create sigs properly', async function () {
       // dummy vote data
       let w = [wallets[0], wallets[4], wallets[6], wallets[7], wallets[5]]
       await checkPoint(w, wallets[1], stakeManager, {
@@ -491,15 +491,15 @@ contract('StakeManager', async functionaccounts) {
   })
 })
 
-contract('StakeManager:rewards distribution', async functionaccounts) {
+contract('StakeManager:rewards distribution', async function (accounts) {
   let stakeToken
   let stakeManager
   let wallets
   let accountState = {}
   const rewardsAmount = 5
 
-  describe('staking rewards', async function) {
-    before(async function) {
+  describe('staking rewards', async function () {
+    before(async function () {
       wallets = generateFirstWallets(mnemonics, 2)
       stakeToken = await DummyERC20.new('Stake Token', 'STAKE')
       stakeManager = await StakeManager.new(
@@ -521,7 +521,7 @@ contract('StakeManager:rewards distribution', async functionaccounts) {
       }
     })
 
-    it('should get rewards for validator [1, 2]', async function) {
+    it('should get rewards for validator [1, 2]', async function () {
       const validators = [1, 2]
       let tree = await rewradsTree(validators, accountState)
       const { vote, sigs } = buildSubmitHeaderBlockPaylod(
@@ -568,7 +568,7 @@ contract('StakeManager:rewards distribution', async functionaccounts) {
   })
 })
 
-contract('StakeManager:validator contract rewards distribution', async function
+contract('StakeManager:validator contract rewards distribution', async function (
   accounts
 ) {
   let stakeToken
@@ -577,8 +577,8 @@ contract('StakeManager:validator contract rewards distribution', async function
   let accountState = {}
   const rewardsAmount = 5
 
-  describe('staking rewards', async function) {
-    before(async function) {
+  describe('staking rewards', async function () {
+    before(async function () {
       wallets = generateFirstWallets(mnemonics, 2)
       stakeToken = await DummyERC20.new('Stake Token', 'STAKE')
       stakeManager = await StakeManager.new(
@@ -600,7 +600,7 @@ contract('StakeManager:validator contract rewards distribution', async function
       }
     })
 
-    it('should get rewards for validator 1 with ValidatorContract/delegation on', async function) {
+    it('should get rewards for validator 1 with ValidatorContract/delegation on', async function () {
       const validators = [1, 2]
       let tree = await rewradsTree(validators, accountState)
       const { vote, sigs } = buildSubmitHeaderBlockPaylod(
@@ -657,15 +657,15 @@ contract('StakeManager:validator contract rewards distribution', async function
   })
 })
 
-contract('StakeManager:validator replacement', async functionaccounts) {
+contract('StakeManager:validator replacement', async function (accounts) {
   let stakeToken
   let stakeManager
   let wallets
   let accountState = {}
   const rewardsAmount = 5
 
-  describe('validator replacement', async function) {
-    before(async function) {
+  describe('validator replacement', async function () {
+    before(async function () {
       wallets = generateFirstWallets(mnemonics, 10)
       stakeToken = await DummyERC20.new('Stake Token', 'STAKE')
       stakeManager = await StakeManager.new(
@@ -688,7 +688,7 @@ contract('StakeManager:validator replacement', async functionaccounts) {
       }
     })
 
-    it('should try auction start in non-auction period and fail', async function) {
+    it('should try auction start in non-auction period and fail', async function () {
       const amount = web3.utils.toWei('1200')
       await stakeToken.mint(wallets[3].getAddressString(), amount)
       await stakeToken.approve(stakeManager.address, amount, {
@@ -705,7 +705,7 @@ contract('StakeManager:validator replacement', async functionaccounts) {
       }
     })
 
-    it('should start Auction and bid multiple times', async function) {
+    it('should start Auction and bid multiple times', async function () {
       let amount = web3.utils.toWei('1200')
       const { vote, sigs } = buildSubmitHeaderBlockPaylod(
         accounts[0],
@@ -779,7 +779,7 @@ contract('StakeManager:validator replacement', async functionaccounts) {
       )
     })
 
-    it('should start auction where validator is last bidder', async function) {
+    it('should start auction where validator is last bidder', async function () {
       const amount = web3.utils.toWei('1250')
       let validator = await stakeManager.validators(2)
       assert(
@@ -800,7 +800,7 @@ contract('StakeManager:validator replacement', async functionaccounts) {
       assert(auctionData.user.toLowerCase() === validator.signer.toLowerCase())
     })
 
-    it('should try to unstake in auction interval and fail', async function) {
+    it('should try to unstake in auction interval and fail', async function () {
       try {
         await stakeManager.unstake(1, {
           from: wallets[0].getAddressString()
@@ -812,7 +812,7 @@ contract('StakeManager:validator replacement', async functionaccounts) {
       }
     })
 
-    it('should try auction start after auctionPeriod period and fail', async function) {
+    it('should try auction start after auctionPeriod period and fail', async function () {
       const { vote, sigs } = buildSubmitHeaderBlockPaylod(
         accounts[0],
         0,
@@ -864,7 +864,7 @@ contract('StakeManager:validator replacement', async functionaccounts) {
       }
     })
 
-    it('should confrim auction and secure the place', async function) {
+    it('should confrim auction and secure the place', async function () {
       const result = await stakeManager.confirmAuctionBid(
         1,
         wallets[4].getAddressString(),
@@ -883,7 +883,7 @@ contract('StakeManager:validator replacement', async functionaccounts) {
       assert.ok(await stakeManager.isValidator(logs[3].args.newValidatorId))
     })
 
-    it('should confrim auction and secure the place for validator itself', async function) {
+    it('should confrim auction and secure the place for validator itself', async function () {
       let validator = await stakeManager.validators(2)
       let stake = validator.amount
       let balanceBefore = await stakeToken.balanceOf(validator.signer)


### PR DESCRIPTION
Few cleanups for stakeManager
- refactored sig check function so that external users can check 2/3 power sigs, and can be used with things like `only2/3Valiadtors`.
- added checkpoint minimum block interval limit to rate-limit the checkpoints with rewards.
- Auction period is fixed now, automatically closes auction period window.