### PR TITLE
Bug fix: sell voucher

### DIFF
--- a/contracts/staking/StakingInfo.sol
+++ b/contracts/staking/StakingInfo.sol
@@ -105,6 +105,11 @@ contract StakingInfo {
         address indexed user,
         uint256 indexed totalStaked
     );
+    event DelUnstaked(
+        address indexed user,
+        uint256 indexed validatorId,
+        uint256 amount
+    );
     event UpdateCommissionRate(
         uint256 indexed validatorId,
         uint256 indexed newCommissionRate,
@@ -358,6 +363,13 @@ contract StakingInfo {
         uint256 totalStaked
     ) public onlyValidatorContract(validatorId) {
         emit DelReStaked(validatorId, user, totalStaked);
+    }
+
+    function logDelUnstaked(uint256 validatorId, address user, uint256 amount)
+        public
+        onlyValidatorContract(validatorId)
+    {
+        emit DelUnstaked(validatorId, user, amount);
     }
 
     function logUpdateCommissionRate(

--- a/contracts/staking/StakingInfo.sol
+++ b/contracts/staking/StakingInfo.sol
@@ -106,8 +106,8 @@ contract StakingInfo {
         uint256 indexed totalStaked
     );
     event DelUnstaked(
-        address indexed user,
         uint256 indexed validatorId,
+        address indexed user,
         uint256 amount
     );
     event UpdateCommissionRate(

--- a/contracts/staking/validatorShare/ValidatorShare.sol
+++ b/contracts/staking/validatorShare/ValidatorShare.sol
@@ -212,6 +212,7 @@ contract ValidatorShare is IValidatorShare {
             ),
             "Insufficent rewards"
         );
+        stakingLogger.logDelUnstaked(validatorId, msg.sender, delegator.amount);
         delete delegators[msg.sender];
     }
 

--- a/contracts/staking/validatorShare/ValidatorShare.sol
+++ b/contracts/staking/validatorShare/ValidatorShare.sol
@@ -106,7 +106,6 @@ contract ValidatorShare is IValidatorShare {
         _burn(msg.sender, share);
         stakeManager.updateValidatorState(validatorId, -int256(_amount));
 
-        activeAmount = activeAmount.sub(_amount);
         if (_amount > amountStaked[msg.sender]) {
             uint256 _rewards = _amount.sub(amountStaked[msg.sender]);
             //withdrawTransfer
@@ -121,6 +120,8 @@ contract ValidatorShare is IValidatorShare {
             _amount = _amount.sub(_rewards);
         }
 
+        activeAmount = activeAmount.sub(_amount);
+
         amountStaked[msg.sender] = 0; // TODO: add partial sell amountStaked[msg.sender].sub(_amount);
         delegators[msg.sender] = Delegator({
             amount: _amount,
@@ -131,6 +132,7 @@ contract ValidatorShare is IValidatorShare {
 
         stakingLogger.logShareBurned(validatorId, msg.sender, _amount, share);
         stakingLogger.logStakeUpdate(validatorId);
+
     }
 
     function withdrawRewards() public {

--- a/contracts/staking/validatorShare/ValidatorShare.sol
+++ b/contracts/staking/validatorShare/ValidatorShare.sol
@@ -132,7 +132,6 @@ contract ValidatorShare is IValidatorShare {
 
         stakingLogger.logShareBurned(validatorId, msg.sender, _amount, share);
         stakingLogger.logStakeUpdate(validatorId);
-
     }
 
     function withdrawRewards() public {

--- a/test/staking/Validator.test.js
+++ b/test/staking/Validator.test.js
@@ -149,7 +149,6 @@ contract('ValidatorShare', async function (accounts) {
     logs[1].event.should.equal('Transfer')
     logs[1].args.from.toLowerCase().should.equal(stakeManager.address.toLowerCase())
     logs[1].args.to.toLowerCase().should.equal(user.toLowerCase())
-    // console.log(logs[2].args.rewards, await validatorContract.rewards())
     // logs[2].args.rewards.should.be.bignumber.equal(await validatorContract.rewards())
     // logs[1].args.value.should.be.bignumber.equal()
     // assertBigNumberEquality(logs[1].args.tokens, web3.utils.toWei('100'))
@@ -184,7 +183,6 @@ contract('ValidatorShare', async function (accounts) {
       from: user
     })
     let logs = logDecoder.decodeLogs(result.receipt.rawLogs)
-    console.log(JSON.stringify(logs))
     logs[2].event.should.equal('ShareBurned')
     // logs[2].args.tokens.should.be.bignumber.equal(await validatorContract.rewards())
     assertBigNumberEquality(logs[2].args.tokens, shares)


### PR DESCRIPTION
- Amount was subtracted from the `activeAmount` which wasn't the correct way because `activeAmount` doesn't include the rewards amount.
- `activeAmount` stores amount locked by delegators, `_amount` is the total amount for one delegator (his `activeAmount`+ his `rewards`.