### PR TITLE
Instead of signer address use signer pubkey

### DIFF
--- a/contracts/staking/StakingInfo.sol
+++ b/contracts/staking/StakingInfo.sol
@@ -25,11 +25,11 @@ contract IStakeManager {
 
 contract StakingInfo {
     event Staked(
-        address indexed signer,
         uint256 indexed validatorId,
         uint256 indexed activationEpoch,
         uint256 amount,
-        uint256 total
+        uint256 total,
+        bytes signerPubkey
     );
     event Unstaked(
         address indexed user,
@@ -48,7 +48,7 @@ contract StakingInfo {
     event SignerChange(
         uint256 indexed validatorId,
         address indexed oldSigner,
-        address indexed newSigner
+        bytes newSignerPubkey
     );
     event ReStaked(uint256 indexed validatorId, uint256 amount, uint256 total);
     event Jailed(uint256 indexed validatorId, uint256 indexed exitEpoch);
@@ -143,13 +143,13 @@ contract StakingInfo {
     }
 
     function logStaked(
-        address signer,
+        bytes memory signerPubkey,
         uint256 validatorId,
         uint256 activationEpoch,
         uint256 amount,
         uint256 total
     ) public onlyStakeManager {
-        emit Staked(signer, validatorId, activationEpoch, amount, total);
+        emit Staked(validatorId, activationEpoch, amount, total, signerPubkey);
     }
 
     function logUnstaked(
@@ -173,9 +173,9 @@ contract StakingInfo {
     function logSignerChange(
         uint256 validatorId,
         address oldSigner,
-        address newSigner
+        bytes memory signerPubkey
     ) public onlyStakeManager {
-        emit SignerChange(validatorId, oldSigner, newSigner);
+        emit SignerChange(validatorId, oldSigner, signerPubkey);
     }
 
     function logReStaked(uint256 validatorId, uint256 amount, uint256 total)

--- a/contracts/staking/StakingInfo.sol
+++ b/contracts/staking/StakingInfo.sol
@@ -25,6 +25,7 @@ contract IStakeManager {
 
 contract StakingInfo {
     event Staked(
+        address indexed signer,
         uint256 indexed validatorId,
         uint256 indexed activationEpoch,
         uint256 amount,
@@ -48,7 +49,8 @@ contract StakingInfo {
     event SignerChange(
         uint256 indexed validatorId,
         address indexed oldSigner,
-        bytes newSignerPubkey
+        address indexed newSigner,
+        bytes signerPubkey
     );
     event ReStaked(uint256 indexed validatorId, uint256 amount, uint256 total);
     event Jailed(uint256 indexed validatorId, uint256 indexed exitEpoch);
@@ -143,13 +145,21 @@ contract StakingInfo {
     }
 
     function logStaked(
+        address signer,
         bytes memory signerPubkey,
         uint256 validatorId,
         uint256 activationEpoch,
         uint256 amount,
         uint256 total
     ) public onlyStakeManager {
-        emit Staked(validatorId, activationEpoch, amount, total, signerPubkey);
+        emit Staked(
+            signer,
+            validatorId,
+            activationEpoch,
+            amount,
+            total,
+            signerPubkey
+        );
     }
 
     function logUnstaked(
@@ -173,9 +183,10 @@ contract StakingInfo {
     function logSignerChange(
         uint256 validatorId,
         address oldSigner,
+        address newSigner,
         bytes memory signerPubkey
     ) public onlyStakeManager {
-        emit SignerChange(validatorId, oldSigner, signerPubkey);
+        emit SignerChange(validatorId, oldSigner, newSigner, signerPubkey);
     }
 
     function logReStaked(uint256 validatorId, uint256 amount, uint256 total)

--- a/contracts/staking/stakeManager/IStakeManager.sol
+++ b/contracts/staking/stakeManager/IStakeManager.sol
@@ -8,8 +8,8 @@ contract IStakeManager is StakeManagerStorage {
     function confirmAuctionBid(
         uint256 validatorId,
         uint256 heimdallFee,
-        address signer,
-        bool acceptDelegation
+        bool acceptDelegation,
+        bytes calldata signerPubkey
     ) external;
 
     function delegationTransfer(
@@ -27,8 +27,8 @@ contract IStakeManager is StakeManagerStorage {
     function stake(
         uint256 amount,
         uint256 heimdallFee,
-        address signer,
-        bool acceptDelegation
+        bool acceptDelegation,
+        bytes calldata signerPubkey
     ) external;
     function unstake(uint256 validatorId) external;
     function totalStakedFor(address addr) external view returns (uint256);
@@ -37,8 +37,8 @@ contract IStakeManager is StakeManagerStorage {
         address user,
         uint256 amount,
         uint256 heimdallFee,
-        address signer,
-        bool acceptDelegation
+        bool acceptDelegation,
+        bytes memory signerPubkey
     ) public;
     function checkSignatures(
         uint256 blockInterval,

--- a/contracts/staking/stakeManager/StakeManager.sol
+++ b/contracts/staking/stakeManager/StakeManager.sol
@@ -546,6 +546,7 @@ contract StakeManager is IStakeManager {
         logger.logSignerChange(
             validatorId,
             validators[validatorId].signer,
+            _signer,
             signerPubkey
         );
 
@@ -686,6 +687,7 @@ contract StakeManager is IStakeManager {
         // no Auctions for 1 dynasty
         validatorAuction[NFTCounter].startEpoch = currentEpoch;
         logger.logStaked(
+            signer,
             signerPubkey,
             NFTCounter,
             currentEpoch,
@@ -739,11 +741,8 @@ contract StakeManager is IStakeManager {
         validatorState[epoch].stakerCount += stakerCount;
     }
 
-    function pubToAddress(bytes memory pub) public pure returns (address addr) {
-        bytes32 hash = keccak256(pub);
-        assembly {
-            mstore(0, hash)
-            addr := mload(0)
-        }
+    function pubToAddress(bytes memory pub) public pure returns (address) {
+        require(pub.length == 64, "Invalid pubkey");
+        return address(uint160(uint256(keccak256(pub))));
     }
 }

--- a/contracts/staking/stakeManager/StakeManager.sol
+++ b/contracts/staking/stakeManager/StakeManager.sol
@@ -546,7 +546,7 @@ contract StakeManager is IStakeManager {
         logger.logSignerChange(
             validatorId,
             validators[validatorId].signer,
-            _signer
+            signerPubkey
         );
 
         delete signerToValidator[validators[validatorId].signer];
@@ -685,7 +685,13 @@ contract StakeManager is IStakeManager {
         updateTimeLine(currentEpoch, int256(amount), 1);
         // no Auctions for 1 dynasty
         validatorAuction[NFTCounter].startEpoch = currentEpoch;
-        logger.logStaked(signer, NFTCounter, currentEpoch, amount, totalStaked);
+        logger.logStaked(
+            signerPubkey,
+            NFTCounter,
+            currentEpoch,
+            amount,
+            totalStaked
+        );
         NFTCounter = NFTCounter.add(1);
     }
 

--- a/scripts/stake.js
+++ b/scripts/stake.js
@@ -14,6 +14,7 @@ async function stake() {
   console.log(process.argv)
   const stakeFor = process.argv[6]
   const amount = web3.utils.toWei(process.argv[7])
+  const pubkey = process.argv[8]
   console.log(`Staking ${amount} for ${stakeFor}...`)
 
   const accounts = await web3.eth.getAccounts()
@@ -23,7 +24,7 @@ async function stake() {
   console.log('Sender accounts has a balanceOf', (await rootToken.balanceOf(accounts[0])).toString())
   await rootToken.approve(stakeManager.address, amount)
   console.log('approved, staking now...')
-  const stake = await stakeManager.stakeFor(stakeFor, amount, 0, stakeFor, false)
+  const stake = await stakeManager.stakeFor(stakeFor, amount, 0, false, pubkey)
   console.log('staked; txHash is', stake.tx)
 }
 
@@ -69,13 +70,13 @@ async function deposit() {
   console.log('deposited', r.tx)
 }
 
-module.exports = async function(callback) {
+module.exports = async function (callback) {
   try {
     await stake()
     // await topUpForFee()
     // await updateValidatorThreshold(20)
     // await deposit()
-  } catch(e) {
+  } catch (e) {
     // truffle exec <script> doesn't throw errors, so handling it in a verbose manner here
     console.log(e)
   }

--- a/test/root/RootChain.test.js
+++ b/test/root/RootChain.test.js
@@ -52,7 +52,7 @@ contract('RootChain', async function (accounts) {
       await stakeToken.approve(stakeManager.address, amount, {
         from: wallets[i].getAddressString()
       })
-      await stakeManager.stake(amount, 0, wallets[i].getAddressString(), false, {
+      await stakeManager.stake(amount, 0, false, wallets[i].getPublicKeyString(), {
         from: wallets[i].getAddressString()
       })
       accountState[i + 1] = 0

--- a/test/staking/SlashingManager.test.js
+++ b/test/staking/SlashingManager.test.js
@@ -48,11 +48,12 @@ contract('SlashingManager', async function (accounts) {
 
   it('should slash validator', async function () {
     const user = wallets[2].getAddressString()
+    const userPubkey = wallets[2].getPublicKeyString()
     const amount = web3.utils.toWei('250')
     await stakeToken.approve(stakeManager.address, amount, {
       from: user
     })
-    await stakeManager.stake(amount, 0, user, false, {
+    await stakeManager.stake(amount, 0, false, userPubkey, {
       from: user
     })
     const beforeStake = await stakeManager.totalStakedFor(user)
@@ -85,12 +86,13 @@ contract('SlashingManager', async function (accounts) {
 
   it('should not slash validator', async function () {
     const user = wallets[2].getAddressString()
+    const userPubkey = wallets[2].getPublicKeyString()
     const amount = web3.utils.toWei('250')
     await stakeToken.approve(stakeManager.address, amount, {
       from: user
     })
 
-    await stakeManager.stake(amount, 0, user, false, {
+    await stakeManager.stake(amount, 0, false, userPubkey, {
       from: user
     })
 

--- a/test/staking/StakeManager.test.js
+++ b/test/staking/StakeManager.test.js
@@ -174,6 +174,7 @@ contract('StakeManager', async function (accounts) {
 
       logs[1].event.should.equal('Staked')
       logs[1].args.signerPubkey.toLowerCase().should.equal(userPubkey.toLowerCase())
+      logs[1].args.signer.toLowerCase().should.equal(user.toLowerCase())
       // logs[2].args.amount.should.be.bignumber.equal(amount)
       assertBigNumberEquality(logs[1].args.amount, web3.utils.toWei('150'))
 
@@ -288,6 +289,7 @@ contract('StakeManager', async function (accounts) {
       const logs = logDecoder.decodeLogs(signerReceipt.receipt.rawLogs)
       logs.should.have.lengthOf(1)
       logs[0].event.should.equal('SignerChange')
+      logs[0].args.newSigner.toLowerCase().should.equal(signer.toLowerCase())
 
       // staked for
       let stakerDetails = await stakeManager.validators(validatorId)

--- a/test/staking/Validator.test.js
+++ b/test/staking/Validator.test.js
@@ -20,6 +20,7 @@ contract('ValidatorShare', async function (accounts) {
 
   beforeEach(async function () {
     let user = wallets[1].getAddressString()
+    const userPubkey = wallets[1].getPublicKeyString()
     let amount = web3.utils.toWei('250')
     const contracts = await deployer.freshDeploy({ stakeManager: true })
     registry = contracts.registry
@@ -44,7 +45,7 @@ contract('ValidatorShare', async function (accounts) {
       from: user
     })
 
-    await stakeManager.stake(amount, 0, user, true, {
+    await stakeManager.stake(amount, 0, true, userPubkey, {
       from: user
     })
     let validator = await stakeManager.validators(1)


### PR DESCRIPTION
- Heimdall requires signer `pubkey` for validator join tx so adding it into the staked event.
- validator struct still stores key extracted from `pubkey`
- signer change also emits an event with `pubkey` so that Heimdall can listen and add that key.
