### PR TITLE
fix: bridge ERC20 tokens from L1 to L2 using `migrations` scripts

### DIFF
--- a/deploy-migrations/4_deploy_child_contracts.js
+++ b/deploy-migrations/4_deploy_child_contracts.js
@@ -4,9 +4,14 @@ const SafeMath = artifacts.require(
   'openzeppelin-solidity/contracts/math/SafeMath.sol'
 )
 const ChildChain = artifacts.require('ChildChain')
+
+const ChildERC20Proxified = artifacts.require('ChildERC20Proxified')
+const ChildERC721Proxified = artifacts.require('ChildERC721Proxified')
+const ChildTokenProxy = artifacts.require('ChildTokenProxy')
+
 const MRC20 = artifacts.require('MRC20')
 
-module.exports = async function(deployer, network, accounts) {
+module.exports = async function(deployer, _, _) {
   deployer.then(async() => {
     await deployer.deploy(SafeMath)
     await deployer.link(SafeMath, [ChildChain])
@@ -15,33 +20,50 @@ module.exports = async function(deployer, network, accounts) {
     const childChain = await ChildChain.deployed()
     const contractAddresses = utils.getContractAddresses()
 
-    let MaticWeth = await childChain.addToken(
-      accounts[0],
-      contractAddresses.root.tokens.MaticWeth,
-      'ETH on Matic',
-      'ETH',
-      18,
-      false // _isERC721
-    )
+    // Deploy MaticWeth (ERC20) child contract and its proxy.
+    // Initialize the contract, update the child chain and map the token with its root contract.
+    const childMaticWethProxified = await ChildERC20Proxified.new()
+    console.log('Child MaticWethProxified contract deployed')
+    const childMaticWethProxy = await ChildTokenProxy.new(childMaticWethProxified.address)
+    console.log('Child MaticWeth proxy contract deployed')
+    const childMaticWeth = await ChildERC20Proxified.at(childMaticWethProxy.address)
 
-    let TestToken = await childChain.addToken(
-      accounts[0],
-      contractAddresses.root.tokens.TestToken,
-      'Test Token',
-      'TST',
-      18,
-      false // _isERC721
-    )
+    await childMaticWeth.initialize(contractAddresses.root.tokens.MaticWeth, 'Eth on Matic', 'ETH', 18)
+    console.log('Child MaticWeth contract initialized')
+    await childMaticWeth.changeChildChain(childChain.address)
+    console.log('Child MaticWeth child chain updated')
+    await childChain.mapToken(contractAddresses.root.tokens.MaticWeth, childMaticWeth.address, false)
+    console.log('Root and child MaticWeth contracts mapped')
 
-    let RootERC721 = await childChain.addToken(
-      accounts[0],
-      contractAddresses.root.tokens.RootERC721,
-      'Test ERC721',
-      'TST721',
-      0,
-      true // _isERC721
-    )
+    // Same thing for TestToken (ERC20).
+    const childTestTokenProxified = await ChildERC20Proxified.new()
+    console.log('Child TestTokenProxified contract deployed')
+    const childTestTokenProxy = await ChildTokenProxy.new(childTestTokenProxified.address)
+    console.log('Child TestToken proxy contract deployed')
+    const childTestToken = await ChildERC20Proxified.at(childTestTokenProxy.address)
 
+    await childTestToken.initialize(contractAddresses.root.tokens.TestToken, 'Test Token', 'TST', 18)
+    console.log('Child TestToken contract initialized')
+    await childTestToken.changeChildChain(childChain.address)
+    console.log('Child TestToken child chain updated')
+    await childChain.mapToken(contractAddresses.root.tokens.TestToken, childTestToken.address, false)
+    console.log('Root and child TestToken contracts mapped')
+
+    // Same thing for TestERC721.
+    const childTestERC721Proxified = await ChildERC721Proxified.new()
+    console.log('Child TestERC721Proxified contract deployed')
+    const childTestERC721Proxy = await ChildTokenProxy.new(childTestERC721Proxified.address)
+    console.log('Child TestERC721 proxy contract deployed')
+    const childTestERC721 = await ChildERC721Proxified.at(childTestERC721Proxy.address)
+
+    await childTestERC721.initialize(contractAddresses.root.tokens.RootERC721, 'Test ERC721', 'TST721')
+    console.log('Child TestERC721 contract initialized')
+    await childTestERC721.changeChildChain(childChain.address)
+    console.log('Child TestERC721 child chain updated')
+    await childChain.mapToken(contractAddresses.root.tokens.RootERC721, childTestERC721.address, true) // ERC721
+    console.log('Root and child testERC721 contracts mapped')
+
+    // Initialize and map MaticToken.
     const maticToken = await MRC20.at('0x0000000000000000000000000000000000001010')
     const maticOwner = await maticToken.owner()
     if (maticOwner === '0x0000000000000000000000000000000000000000') {
@@ -51,12 +73,12 @@ module.exports = async function(deployer, network, accounts) {
     await childChain.mapToken(contractAddresses.root.tokens.MaticToken, '0x0000000000000000000000000000000000001010', false)
 
     contractAddresses.child = {
-      ChildChain: ChildChain.address,
+      ChildChain: childChain.address,
       tokens: {
-        MaticWeth: MaticWeth.logs.find(log => log.event === 'NewToken').args.token,
+        MaticWeth: childMaticWeth.address,
         MaticToken: '0x0000000000000000000000000000000000001010',
-        TestToken: TestToken.logs.find(log => log.event === 'NewToken').args.token,
-        RootERC721: RootERC721.logs.find(log => log.event === 'NewToken').args.token
+        TestToken: childTestToken.address,
+        RootERC721: childTestERC721.address
       }
     }
     utils.writeContractAddresses(contractAddresses)

--- a/deploy-migrations/4_deploy_child_contracts.js
+++ b/deploy-migrations/4_deploy_child_contracts.js
@@ -37,7 +37,7 @@ module.exports = async function(deployer, _, _) {
 
     // Same thing for TestToken (ERC20).
     const childTestTokenProxified = await ChildERC20Proxified.new()
-    console.log('Child TestTokenProxified contract deployed')
+    console.log('\nChild TestTokenProxified contract deployed')
     const childTestTokenProxy = await ChildTokenProxy.new(childTestTokenProxified.address)
     console.log('Child TestToken proxy contract deployed')
     const childTestToken = await ChildERC20Proxified.at(childTestTokenProxy.address)
@@ -51,7 +51,7 @@ module.exports = async function(deployer, _, _) {
 
     // Same thing for TestERC721.
     const childTestERC721Proxified = await ChildERC721Proxified.new()
-    console.log('Child TestERC721Proxified contract deployed')
+    console.log('\nChild TestERC721Proxified contract deployed')
     const childTestERC721Proxy = await ChildTokenProxy.new(childTestERC721Proxified.address)
     console.log('Child TestERC721 proxy contract deployed')
     const childTestERC721 = await ChildERC721Proxified.at(childTestERC721Proxy.address)

--- a/migrations/5_deploy_child_contracts.js
+++ b/migrations/5_deploy_child_contracts.js
@@ -5,6 +5,7 @@ const SafeMath = artifacts.require(
 )
 const ChildChain = artifacts.require('ChildChain')
 const MRC20 = artifacts.require('MRC20')
+const ChildToken = artifacts.require('ChildToken')
 
 module.exports = async function(deployer, network, accounts) {
   if (deployer.network !== 'bor') {
@@ -27,9 +28,9 @@ module.exports = async function(deployer, network, accounts) {
       18,
       false // _isERC721
     )
-    await MaticWeth.changeChildChain(ChildChain.address)
+    //await MaticWeth.changeChildChain(ChildChain.address)
 
-    let TestToken = await childChain.addToken(
+    const addTestTokenToChildChainTx = await childChain.addToken(
       accounts[0],
       contractAddresses.root.tokens.TestToken,
       'Test Token',
@@ -37,7 +38,9 @@ module.exports = async function(deployer, network, accounts) {
       18,
       false // _isERC721
     )
-    await TestToken.changeChildChain(ChildChain.address)
+    const childTestTokenAddress = addTestTokenToChildChainTx.logs.find(log => log.event === 'NewToken').args.token
+    const childTesTokenContract = await ChildToken.at(childTestTokenAddress)
+    await childTesTokenContract.changeChildChain(ChildChain.address, {from: ChildChain.address})
 
     let RootERC721 = await childChain.addToken(
       accounts[0],
@@ -47,7 +50,7 @@ module.exports = async function(deployer, network, accounts) {
       0,
       true // _isERC721
     )
-    await RootERC721.changeChildChain(ChildChain.address)
+    //await RootERC721.changeChildChain(ChildChain.address)
 
     const maticToken = await MRC20.at('0x0000000000000000000000000000000000001010')
     const maticOwner = await maticToken.owner()

--- a/migrations/5_deploy_child_contracts.js
+++ b/migrations/5_deploy_child_contracts.js
@@ -27,6 +27,7 @@ module.exports = async function(deployer, network, accounts) {
       18,
       false // _isERC721
     )
+    await MaticWeth.changeChildChain(ChildChain.address)
 
     let TestToken = await childChain.addToken(
       accounts[0],
@@ -36,6 +37,7 @@ module.exports = async function(deployer, network, accounts) {
       18,
       false // _isERC721
     )
+    await TestToken.changeChildChain(ChildChain.address)
 
     let RootERC721 = await childChain.addToken(
       accounts[0],
@@ -45,6 +47,7 @@ module.exports = async function(deployer, network, accounts) {
       0,
       true // _isERC721
     )
+    await RootERC721.changeChildChain(ChildChain.address)
 
     const maticToken = await MRC20.at('0x0000000000000000000000000000000000001010')
     const maticOwner = await maticToken.owner()

--- a/migrations/5_deploy_child_contracts.js
+++ b/migrations/5_deploy_child_contracts.js
@@ -31,7 +31,7 @@ module.exports = async function(deployer, network, accounts) {
     )
     const maticWethAddress = maticWethTx.logs.find(log => log.event === 'NewToken').args.token
     const maticWethContract = await ChildERC20.at(maticWethAddress)
-    await maticWethContract.changeChildChain(contractAddresses.child.ChildChain, {from: accounts[0]})
+    await maticWethContract.changeChildChain(childChain.address, {from: accounts[0]})
 
     const testERC20Tx = await childChain.addToken(
       accounts[0],
@@ -43,7 +43,7 @@ module.exports = async function(deployer, network, accounts) {
     )
     const testERC20Address = testERC20Tx.logs.find(log => log.event === 'NewToken').args.token
     const testERC20Contract = await ChildERC20.at(testERC20Address)
-    await testERC20Contract.changeChildChain(contractAddresses.child.ChildChain, {from: accounts[0]})
+    await testERC20Contract.changeChildChain(childChain.address, {from: accounts[0]})
 
     const testERC721Tx = await childChain.addToken(
       accounts[0],
@@ -55,7 +55,7 @@ module.exports = async function(deployer, network, accounts) {
     )
     const testERC721Address = testERC721Tx.logs.find(log => log.event === 'NewToken').args.token
     const testERC721Contract = await ChildERC721.at(maticWethAddress)
-    await testERC721Contract.changeChildChain(contractAddresses.child.ChildChain, {from: accounts[0]})
+    await testERC721Contract.changeChildChain(childChain.address, {from: accounts[0]})
 
     const maticToken = await MRC20.at('0x0000000000000000000000000000000000001010')
     const maticOwner = await maticToken.owner()

--- a/migrations/5_deploy_child_contracts.js
+++ b/migrations/5_deploy_child_contracts.js
@@ -27,45 +27,45 @@ module.exports = async function(deployer, _, _) {
     // Deploy MaticWeth (ERC20) child contract and its proxy.
     // Initialize the contract, update the child chain and map the token with its root contract.
     const childMaticWethProxified = await ChildERC20Proxified.new()
-    console.log('childMaticWethProxified deployed')
+    console.log('Child MaticWethProxified contract deployed')
     const childMaticWethProxy = await ChildTokenProxy.new(childMaticWethProxified.address)
-    console.log('childMaticWethProxy deployed')
+    console.log('Child MaticWeth proxy contract deployed')
     const childMaticWeth = await ChildERC20Proxified.at(childMaticWethProxy.address)
 
     await childMaticWeth.initialize(contractAddresses.root.tokens.MaticWeth, 'Eth on Matic', 'ETH', 18)
-    console.log('childMaticWeth initialized')
+    console.log('Child MaticWeth contract initialized')
     await childMaticWeth.changeChildChain(childChain.address)
-    console.log('childMaticWeth child chain updated')
+    console.log('Child MaticWeth child chain updated')
     await childChain.mapToken(contractAddresses.root.tokens.MaticWeth, childMaticWeth.address, false)
-    console.log('root and child maticWeth mapped')
+    console.log('Root and child MaticWeth contracts mapped')
 
     // Same thing for TestToken (ERC20).
     const childTestTokenProxified = await ChildERC20Proxified.new()
-    console.log('childTestTokenProxified deployed')
+    console.log('Child TestTokenProxified contract deployed')
     const childTestTokenProxy = await ChildTokenProxy.new(childTestTokenProxified.address)
-    console.log('childTestTokenProxy deployed')
+    console.log('Child TestToken proxy contract deployed')
     const childTestToken = await ChildERC20Proxified.at(childTestTokenProxy.address)
 
     await childTestToken.initialize(contractAddresses.root.tokens.TestToken, 'Test Token', 'TST', 18)
-    console.log('childTestToken initialized')
+    console.log('Child TestToken contract initialized')
     await childTestToken.changeChildChain(childChain.address)
-    console.log('childTestToken child chain updated')
+    console.log('Child TestToken child chain updated')
     await childChain.mapToken(contractAddresses.root.tokens.TestToken, childTestToken.address, false)
-    console.log('root and child testToken mapped')
+    console.log('Root and child TestToken contracts mapped')
 
     // Same thing for TestERC721.
     const childTestERC721Proxified = await ChildERC721Proxified.new()
-    console.log('childTestERC721Proxified deployed')
+    console.log('Child TestERC721Proxified contract deployed')
     const childTestERC721Proxy = await ChildTokenProxy.new(childTestERC721Proxified.address)
-    console.log('childTestERC721Proxy deployed')
+    console.log('Child TestERC721 proxy contract deployed')
     const childTestERC721 = await ChildERC721Proxified.at(childTestERC721Proxy.address)
 
     await childTestERC721.initialize(contractAddresses.root.tokens.RootERC721, 'Test ERC721', 'TST721')
-    console.log('childTestERC721 initialized')
+    console.log('Child TestERC721 contract initialized')
     await childTestERC721.changeChildChain(childChain.address)
-    console.log('childTestERC721 child chain updated')
+    console.log('Child TestERC721 child chain updated')
     await childChain.mapToken(contractAddresses.root.tokens.RootERC721, childTestERC721.address, true) // ERC721
-    console.log('root and child testERC721 mapped')
+    console.log('Root and child testERC721 contracts mapped')
 
     // Initialize and map MaticToken.
     const maticToken = await MRC20.at('0x0000000000000000000000000000000000001010')

--- a/migrations/5_deploy_child_contracts.js
+++ b/migrations/5_deploy_child_contracts.js
@@ -41,7 +41,7 @@ module.exports = async function(deployer, _, _) {
 
     // Same thing for TestToken (ERC20).
     const childTestTokenProxified = await ChildERC20Proxified.new()
-    console.log('Child TestTokenProxified contract deployed')
+    console.log('\nChild TestTokenProxified contract deployed')
     const childTestTokenProxy = await ChildTokenProxy.new(childTestTokenProxified.address)
     console.log('Child TestToken proxy contract deployed')
     const childTestToken = await ChildERC20Proxified.at(childTestTokenProxy.address)
@@ -55,7 +55,7 @@ module.exports = async function(deployer, _, _) {
 
     // Same thing for TestERC721.
     const childTestERC721Proxified = await ChildERC721Proxified.new()
-    console.log('Child TestERC721Proxified contract deployed')
+    console.log('\nChild TestERC721Proxified contract deployed')
     const childTestERC721Proxy = await ChildTokenProxy.new(childTestERC721Proxified.address)
     console.log('Child TestERC721 proxy contract deployed')
     const childTestERC721 = await ChildERC721Proxified.at(childTestERC721Proxy.address)

--- a/migrations/5_deploy_child_contracts.js
+++ b/migrations/5_deploy_child_contracts.js
@@ -11,7 +11,7 @@ const ChildTokenProxy = artifacts.require('ChildTokenProxy')
 
 const MRC20 = artifacts.require('MRC20')
 
-module.exports = async function(deployer, network, accounts) {
+module.exports = async function(deployer, _, _) {
   if (deployer.network !== 'bor') {
     return
   }
@@ -27,30 +27,45 @@ module.exports = async function(deployer, network, accounts) {
     // Deploy MaticWeth (ERC20) child contract and its proxy.
     // Initialize the contract, update the child chain and map the token with its root contract.
     const childMaticWethProxified = await ChildERC20Proxified.new()
+    console.log('childMaticWethProxified deployed')
     const childMaticWethProxy = await ChildTokenProxy.new(childMaticWethProxified.address)
+    console.log('childMaticWethProxy deployed')
     const childMaticWeth = await ChildERC20Proxified.at(childMaticWethProxy.address)
 
     await childMaticWeth.initialize(contractAddresses.root.tokens.MaticWeth, 'Eth on Matic', 'ETH', 18)
+    console.log('childMaticWeth initialized')
     await childMaticWeth.changeChildChain(childChain.address)
+    console.log('childMaticWeth child chain updated')
     await childChain.mapToken(contractAddresses.root.tokens.MaticWeth, childMaticWeth.address, false)
+    console.log('root and child maticWeth mapped')
 
     // Same thing for TestToken (ERC20).
     const childTestTokenProxified = await ChildERC20Proxified.new()
+    console.log('childTestTokenProxified deployed')
     const childTestTokenProxy = await ChildTokenProxy.new(childTestTokenProxified.address)
+    console.log('childTestTokenProxy deployed')
     const childTestToken = await ChildERC20Proxified.at(childTestTokenProxy.address)
 
     await childTestToken.initialize(contractAddresses.root.tokens.TestToken, 'Test Token', 'TST', 18)
+    console.log('childTestToken initialized')
     await childTestToken.changeChildChain(childChain.address)
+    console.log('childTestToken child chain updated')
     await childChain.mapToken(contractAddresses.root.tokens.TestToken, childTestToken.address, false)
+    console.log('root and child testToken mapped')
 
     // Same thing for TestERC721.
     const childTestERC721Proxified = await ChildERC721Proxified.new()
+    console.log('childTestERC721Proxified deployed')
     const childTestERC721Proxy = await ChildTokenProxy.new(childTestERC721Proxified.address)
+    console.log('childTestERC721Proxy deployed')
     const childTestERC721 = await ChildERC721Proxified.at(childTestERC721Proxy.address)
 
     await childTestERC721.initialize(contractAddresses.root.tokens.RootERC721, 'Test ERC721', 'TST721')
+    console.log('childTestERC721 initialized')
     await childTestERC721.changeChildChain(childChain.address)
+    console.log('childTestERC721 child chain updated')
     await childChain.mapToken(contractAddresses.root.tokens.RootERC721, childTestERC721.address, true) // ERC721
+    console.log('root and child testERC721 mapped')
 
     // Initialize and map MaticToken.
     const maticToken = await MRC20.at('0x0000000000000000000000000000000000001010')

--- a/migrations/5_deploy_child_contracts.js
+++ b/migrations/5_deploy_child_contracts.js
@@ -48,7 +48,7 @@ module.exports = async function(deployer, network, accounts) {
     const childTestERC721Proxy = await deployer.deploy(ChildTokenProxy, childTestERC721Proxified.address)
     const childTestERC721 = await ChildERC721Proxified.at(childTestERC721Proxy.address)
 
-    await childTestERC721.initialize(contractAddresses.root.tokens.RootERC721, 'Test ERC721', 'TST721', 0)
+    await childTestERC721.initialize(contractAddresses.root.tokens.RootERC721, 'Test ERC721', 'TST721')
     await childTestERC721.changeChildChain(childChain.address)
     await childChain.mapToken(contractAddresses.root.tokens.RootERC721, childTestERC721.address, true) // ERC721
 

--- a/migrations/5_deploy_child_contracts.js
+++ b/migrations/5_deploy_child_contracts.js
@@ -21,7 +21,7 @@ module.exports = async function(deployer, network, accounts) {
     const childChain = await ChildChain.deployed()
     const contractAddresses = utils.getContractAddresses()
 
-    const maticWethTx = await childChain.addToken(
+    const addTokenMaticWethTx = await childChain.addToken(
       accounts[0],
       contractAddresses.root.tokens.MaticWeth,
       'ETH on Matic',
@@ -29,11 +29,11 @@ module.exports = async function(deployer, network, accounts) {
       18,
       false // _isERC721
     )
-    const maticWethAddress = maticWethTx.logs.find(log => log.event === 'NewToken').args.token
-    const maticWethContract = await ChildERC20.at(maticWethAddress)
-    await maticWethContract.changeChildChain(childChain.address, {from: accounts[0]})
+    const maticWethAddress = addTokenMaticWethTx.logs.find(log => log.event === 'NewToken').args.token
+    const maticWeth = await ChildERC20.at(maticWethAddress)
+    await maticWeth.changeChildChain(childChain.address, {from: accounts[0]})
 
-    const testERC20Tx = await childChain.addToken(
+    const addTokenTestERC20Tx = await childChain.addToken(
       accounts[0],
       contractAddresses.root.tokens.TestToken,
       'Test Token',
@@ -41,11 +41,11 @@ module.exports = async function(deployer, network, accounts) {
       18,
       false // _isERC721
     )
-    const testERC20Address = testERC20Tx.logs.find(log => log.event === 'NewToken').args.token
-    const testERC20Contract = await ChildERC20.at(testERC20Address)
-    await testERC20Contract.changeChildChain(childChain.address, {from: accounts[0]})
+    const testERC20Address = addTokenTestERC20Tx.logs.find(log => log.event === 'NewToken').args.token
+    const testERC20 = await ChildERC20.at(testERC20Address)
+    await testERC20.changeChildChain(childChain.address, {from: accounts[0]})
 
-    const testERC721Tx = await childChain.addToken(
+    const addTokenTestERC721Tx = await childChain.addToken(
       accounts[0],
       contractAddresses.root.tokens.RootERC721,
       'Test ERC721',
@@ -53,9 +53,9 @@ module.exports = async function(deployer, network, accounts) {
       0,
       true // _isERC721
     )
-    const testERC721Address = testERC721Tx.logs.find(log => log.event === 'NewToken').args.token
-    const testERC721Contract = await ChildERC721.at(maticWethAddress)
-    await testERC721Contract.changeChildChain(childChain.address, {from: accounts[0]})
+    const testERC721Address = addTokenTestERC721Tx.logs.find(log => log.event === 'NewToken').args.token
+    const testERC721 = await ChildERC721.at(testERC721Address)
+    await testERC721.changeChildChain(childChain.address, {from: accounts[0]})
 
     const maticToken = await MRC20.at('0x0000000000000000000000000000000000001010')
     const maticOwner = await maticToken.owner()

--- a/migrations/5_deploy_child_contracts.js
+++ b/migrations/5_deploy_child_contracts.js
@@ -4,11 +4,12 @@ const SafeMath = artifacts.require(
   'openzeppelin-solidity/contracts/math/SafeMath.sol'
 )
 const ChildChain = artifacts.require('ChildChain')
-const MRC20 = artifacts.require('MRC20')
 
 const ChildERC20Proxified = artifacts.require('ChildERC20Proxified')
 const ChildERC721Proxified = artifacts.require('ChildERC721Proxified')
 const ChildTokenProxy = artifacts.require('ChildTokenProxy')
+
+const MRC20 = artifacts.require('MRC20')
 
 module.exports = async function(deployer, network, accounts) {
   if (deployer.network !== 'bor') {
@@ -32,7 +33,6 @@ module.exports = async function(deployer, network, accounts) {
     await childMaticWeth.initialize(contractAddresses.root.tokens.MaticWeth, 'Eth on Matic', 'ETH', 18)
     await childMaticWeth.changeChildChain(childChain.address)
     await childChain.mapToken(contractAddresses.root.tokens.MaticWeth, childMaticWeth.address, false)
-
 
     // Same thing for TestToken (ERC20).
     const childTestTokenProxified = await ChildERC20Proxified.new()

--- a/migrations/5_deploy_child_contracts.js
+++ b/migrations/5_deploy_child_contracts.js
@@ -28,6 +28,7 @@ module.exports = async function(deployer, network, accounts) {
     const childMaticWethProxified = await deployer.deploy(ChildERC20Proxified)
     const childMaticWethProxy = await deployer.deploy(ChildTokenProxy, childMaticWethProxified.address)
     const childMaticWeth = await ChildERC20Proxified.at(childMaticWethProxy.address)
+
     await childMaticWeth.initialize(contractAddresses.root.tokens.MaticWeth, 'Eth on Matic', 'ETH', 18)
     await childMaticWeth.changeChildChain(childChain.address)
     await childChain.mapToken(contractAddresses.root.tokens.MaticWeth, childMaticWeth.address, false)
@@ -37,6 +38,7 @@ module.exports = async function(deployer, network, accounts) {
     const childTestTokenProxified = await deployer.deploy(ChildERC20Proxified)
     const childTestTokenProxy = await deployer.deploy(ChildTokenProxy, childTestTokenProxified.address)
     const childTestToken = await ChildERC20Proxified.at(childTestTokenProxy.address)
+
     await childTestToken.initialize(contractAddresses.root.tokens.TestToken, 'Test Token', 'TST', 18)
     await childTestToken.changeChildChain(childChain.address)
     await childChain.mapToken(contractAddresses.root.tokens.TestToken, childTestToken.address, false)
@@ -45,7 +47,8 @@ module.exports = async function(deployer, network, accounts) {
     const childTestERC721Proxified = await deployer.deploy(ChildERC721Proxified)
     const childTestERC721Proxy = await deployer.deploy(ChildTokenProxy, childTestERC721Proxified.address)
     const childTestERC721 = await ChildERC721Proxified.at(childTestERC721Proxy.address)
-    await childTestERC721.initialize(contractAddresses.root.tokens.TestToken, 'Test ERC721', 'TST721', 0)
+
+    await childTestERC721.initialize(contractAddresses.root.tokens.RootERC721, 'Test ERC721', 'TST721', 0)
     await childTestERC721.changeChildChain(childChain.address)
     await childChain.mapToken(contractAddresses.root.tokens.RootERC721, childTestERC721.address, true) // ERC721
 

--- a/migrations/5_deploy_child_contracts.js
+++ b/migrations/5_deploy_child_contracts.js
@@ -25,8 +25,8 @@ module.exports = async function(deployer, network, accounts) {
 
     // Deploy MaticWeth (ERC20) child contract and its proxy.
     // Initialize the contract, update the child chain and map the token with its root contract.
-    const childMaticWethProxified = await deployer.deploy(ChildERC20Proxified)
-    const childMaticWethProxy = await deployer.deploy(ChildTokenProxy, childMaticWethProxified.address)
+    const childMaticWethProxified = await ChildERC20Proxified.new()
+    const childMaticWethProxy = await ChildTokenProxy.new(childMaticWethProxified.address)
     const childMaticWeth = await ChildERC20Proxified.at(childMaticWethProxy.address)
 
     await childMaticWeth.initialize(contractAddresses.root.tokens.MaticWeth, 'Eth on Matic', 'ETH', 18)
@@ -35,8 +35,8 @@ module.exports = async function(deployer, network, accounts) {
 
 
     // Same thing for TestToken (ERC20).
-    const childTestTokenProxified = await deployer.deploy(ChildERC20Proxified)
-    const childTestTokenProxy = await deployer.deploy(ChildTokenProxy, childTestTokenProxified.address)
+    const childTestTokenProxified = await ChildERC20Proxified.new()
+    const childTestTokenProxy = await ChildTokenProxy.new(childTestTokenProxified.address)
     const childTestToken = await ChildERC20Proxified.at(childTestTokenProxy.address)
 
     await childTestToken.initialize(contractAddresses.root.tokens.TestToken, 'Test Token', 'TST', 18)
@@ -44,8 +44,8 @@ module.exports = async function(deployer, network, accounts) {
     await childChain.mapToken(contractAddresses.root.tokens.TestToken, childTestToken.address, false)
 
     // Same thing for TestERC721.
-    const childTestERC721Proxified = await deployer.deploy(ChildERC721Proxified)
-    const childTestERC721Proxy = await deployer.deploy(ChildTokenProxy, childTestERC721Proxified.address)
+    const childTestERC721Proxified = await ChildERC721Proxified.new()
+    const childTestERC721Proxy = await ChildTokenProxy.new(childTestERC721Proxified.address)
     const childTestERC721 = await ChildERC721Proxified.at(childTestERC721Proxy.address)
 
     await childTestERC721.initialize(contractAddresses.root.tokens.RootERC721, 'Test ERC721', 'TST721')


### PR DESCRIPTION
## Description

The initial approach involved using `childChain.addToken` to create `ChildERC20` and `ChildERC721` contracts, but this rendered them unusable due to ownership issues. In this scenario, the `ChildChain` contract became the owner, preventing updates to the child chain address and leaving it set to `0x0`. Consequently, attempts to bridge resulted in reverting transactions (with no explicit error message 😅) due to the restrictive `onlyChildChain` modifier (see https://github.com/maticnetwork/matic-cli/issues/210).

https://github.com/maticnetwork/contracts/blob/ba520b66689c52756cbead8ab5db426f19d3badd/contracts/child/ChildChain.sol#L55-L76

https://github.com/maticnetwork/contracts/blob/ba520b66689c52756cbead8ab5db426f19d3badd/contracts/child/ChildERC20.sol#L11-L21

https://github.com/maticnetwork/contracts/blob/ba520b66689c52756cbead8ab5db426f19d3badd/contracts/child/ChildToken.sol#L79-L87

The revised logic aligns with the updated scripts, employing `ChildERC20Proxified` and `ChildERC721Proxified` for token creation. This approach allows for proper initialisation, subsequent child chain address updates, and token mapping. As a result, the `ChildChain` contract can seamlessly send tokens to our L2 address as intended.

## Jira Ticket

- [DVT-1083](https://polygon.atlassian.net/browse/DVT-1083)

## Test

New deployment.

```sh
$ truffle migrate --network bor --f 5 --to 5
> truffle migrate --network bor

Compiling your contracts...
===========================
> Everything is up to date, there is nothing to compile.


Starting migrations...
======================
> Network name:    'bor'
> Network id:      15005
> Block gas limit: 10127680 (0x9a8940)

5_deploy_child_contracts.js
===========================

   Deploying 'SafeMath'
   --------------------
   > transaction hash:    0xc946a0a6f0aa40e62cbfe74013f633f28b44127b1c109e4c9bbadf128c4c235b
   > Blocks: 2            Seconds: 4
   > contract address:    0xa487178053E36129Fe5E54b02bE55C00c5B9225F
   > block number:        17
   > block timestamp:     1701078587
   > account:             0x6447Ef2275Dc1Cc203dC54C4d71693Ea795f87C2
   > balance:             999999999.999992591319673058
   > gas used:            71714 (0x11822)
   > gas price:           90 gwei
   > value sent:          0 ETH
   > total cost:          0.00645426 ETH


   Deploying 'ChildChain'
   ----------------------
   > transaction hash:    0x45debf284bced9f80bcc099022b1238e28d8e414b0bd022735fc07e57aaf1ca1
   > Blocks: 2            Seconds: 4
   > contract address:    0xba8D14e74bFD3F57C6a5BD449a80A02bE5BA62e6
   > block number:        19
   > block timestamp:     1701078591
   > account:             0x6447Ef2275Dc1Cc203dC54C4d71693Ea795f87C2
   > balance:             999999999.999575991589673183
   > gas used:            5256439 (0x5034f7)
   > gas price:           90 gwei
   > value sent:          0 ETH
   > total cost:          0.47307951 ETH

Child MaticWethProxified contract deployed
Child MaticWeth proxy contract deployed
Child MaticWeth contract initialized
Child MaticWeth child chain updated
Root and child MaticWeth contracts mapped

Child TestTokenProxified contract deployed
Child TestToken proxy contract deployed
Child TestToken contract initialized
Child TestToken child chain updated
Root and child TestToken contracts mapped

Child TestERC721Proxified contract deployed
Child TestERC721 proxy contract deployed
Child TestERC721 contract initialized
Child TestERC721 child chain updated
Root and child testERC721 contracts mapped
   > Saving artifacts
   -------------------------------------
   > Total cost:          0.47953377 ETH

Summary
=======
> Total deployments:   2
> Final cost:          0.47953377 ETH
```

After bridging some ether and ERC20 tokens.

![image](https://github.com/maticnetwork/contracts/assets/28714795/32390993-1d03-4ef5-ae81-041174ceee44)

