### PR TITLE
fix depositBulk using mapToken

### DIFF
--- a/contracts/root/depositManager/DepositManager.sol
+++ b/contracts/root/depositManager/DepositManager.sol
@@ -25,7 +25,7 @@ contract DepositManager is DepositManagerStorage, IDepositManager, ERC721Holder 
     modifier isTokenMapped(address _token) {
         // new: exception for POL token
         require(
-            registry.isTokenMapped(_token) || _token == registry.contractMap(keccak256("pol")),
+            registry.isTokenMapped(_token),
             "TOKEN_NOT_SUPPORTED"
         );
         _;


### PR DESCRIPTION
Instead of adding the second exception, we map POL in the registry using `mapToken`

new exitQueue is created but does not affect operations.
childToRootToken is overwritten, but also does not affect bridging.
(only ...BurnOnly predicates are being used, not the old ones)

This solves both instances where exceptions would have been necessary.
This also creates a more accurate representation of the truth in the registry mappings. (rootToChildToken)
